### PR TITLE
fix(ci): revert repo-operator workflow pins to @main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
             shutdown-orchestrator:
               - 'cmd/shutdown-orchestrator/**'
   lint:
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_lint.yaml@main"
     secrets: "inherit"
   kubeconform:
     needs: "changes"
@@ -80,4 +80,4 @@ jobs:
       - "flux-differ"
       - "shutdown-orchestrator"
     if: "always()"
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_summary.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_summary.yaml@main"

--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -11,4 +11,4 @@ permissions:
   issues: "write"
 jobs:
   scan:
-    uses: "anthony-spruyt/repo-operator/.github/workflows/_trivy-scan.yaml@605fcdfab864797e519666120966a1e2b999eb0b" # main
+    uses: "anthony-spruyt/repo-operator/.github/workflows/_trivy-scan.yaml@main"


### PR DESCRIPTION
## Summary

- Reverts digest-pinned references to `anthony-spruyt/repo-operator` reusable workflows back to `@main` in `.github/workflows/ci.yaml` and `.github/workflows/trivy-scan.yaml`
- Digest pinning adds churn (every repo-operator commit changes the hash) with no security benefit since repo-operator already has write access to this repo via xfg sync

## Test plan

- [ ] CI workflow runs successfully with `@main` references
- [ ] Trivy scan workflow triggers correctly on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)