### PR TITLE
feat(claude-agents): add per-agent MCP settings profiles via --settings

### DIFF
--- a/cluster/apps/claude-agents-shared/README.md
+++ b/cluster/apps/claude-agents-shared/README.md
@@ -11,7 +11,7 @@ Each agent namespace references this base via its `kustomization.yaml` and only 
 ```text
 claude-agents-shared/
   base/
-    kustomization.yaml              # Resource list for the shared base
+    kustomization.yaml              # Resource list + configMapGenerator for settings
     claude-mcp-config.yaml          # MCP server endpoints and auth headers
     mcp-credentials.sops.yaml       # SOPS-encrypted API keys for MCP servers
     rbac.yaml                       # ServiceAccount for agent pods
@@ -21,7 +21,43 @@ claude-agents-shared/
     github-ssh-external-secret.yaml # ESO ExternalSecret for SSH key
     github-bot-gitconfig.yaml       # Git config (signing, user identity)
     github-rotation-rbac.yaml       # RBAC for token rotation CronJob
+    settings/                       # Claude Code settings profiles (deniedMcpServers)
+      sre.json                      # SRE agents: kubectl, victoriametrics, sre, discord
+      dev.json                      # Dev agents: github, context7, bravesearch
+      minimal.json                  # Minimal: github + context7 only
+      full.json                     # Full: all MCP servers enabled
+      generic.json                  # Generic: no-repo work (github, context7, sre, discord, bravesearch)
 ```
+
+## Settings Profiles
+
+Each profile is a Claude Code `settings.json` that uses `deniedMcpServers` to blacklist MCP servers not needed for that agent role. All MCP servers remain configured in `claude-mcp-config.yaml` — profiles only control which are denied at runtime.
+
+Profiles are bundled into a `claude-settings-profiles` ConfigMap via `configMapGenerator` and mounted at `/etc/claude/settings/` in all agent pods by the Kyverno injection policy.
+
+### Usage in n8n
+
+Set **Additional Arguments** on the Claude Code CLI node:
+
+```text
+--settings /etc/claude/settings/sre.json
+```
+
+### Adding a New Profile
+
+1. Create a new JSON file in `base/settings/`:
+
+```json
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "deniedMcpServers": [
+    { "serverName": "server-to-deny" }
+  ]
+}
+```
+
+2. Add the file to `configMapGenerator.files` in `base/kustomization.yaml`
+3. Commit and push — new pods will pick up the profile automatically
 
 ## Adding a New MCP Server
 

--- a/cluster/apps/claude-agents-shared/base/kustomization.yaml
+++ b/cluster/apps/claude-agents-shared/base/kustomization.yaml
@@ -12,3 +12,13 @@ resources:
   - ./github-rotation-rbac.yaml
   - ./claude-mcp-config.yaml
   - ./mcp-credentials.sops.yaml
+configMapGenerator:
+  - name: claude-settings-profiles
+    files:
+      - settings/sre.json
+      - settings/dev.json
+      - settings/minimal.json
+      - settings/full.json
+      - settings/generic.json
+generatorOptions:
+  disableNameSuffixHash: true

--- a/cluster/apps/claude-agents-shared/base/settings/dev.json
+++ b/cluster/apps/claude-agents-shared/base/settings/dev.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "deniedMcpServers": [
+    { "serverName": "kubectl" },
+    { "serverName": "victoriametrics" },
+    { "serverName": "sre" },
+    { "serverName": "discord" },
+    { "serverName": "homeassistant" }
+  ]
+}

--- a/cluster/apps/claude-agents-shared/base/settings/full.json
+++ b/cluster/apps/claude-agents-shared/base/settings/full.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json"
+}

--- a/cluster/apps/claude-agents-shared/base/settings/generic.json
+++ b/cluster/apps/claude-agents-shared/base/settings/generic.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "deniedMcpServers": [
+    { "serverName": "kubectl" },
+    { "serverName": "victoriametrics" },
+    { "serverName": "homeassistant" }
+  ]
+}

--- a/cluster/apps/claude-agents-shared/base/settings/minimal.json
+++ b/cluster/apps/claude-agents-shared/base/settings/minimal.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "deniedMcpServers": [
+    { "serverName": "kubectl" },
+    { "serverName": "victoriametrics" },
+    { "serverName": "sre" },
+    { "serverName": "discord" },
+    { "serverName": "homeassistant" },
+    { "serverName": "bravesearch" }
+  ]
+}

--- a/cluster/apps/claude-agents-shared/base/settings/sre.json
+++ b/cluster/apps/claude-agents-shared/base/settings/sre.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "deniedMcpServers": [
+    { "serverName": "context7" },
+    { "serverName": "bravesearch" },
+    { "serverName": "homeassistant" }
+  ]
+}

--- a/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
+++ b/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
@@ -48,6 +48,9 @@ spec:
               - name: claude-mcp-config
                 configMap:
                   name: claude-mcp-config
+              - name: claude-settings-profiles
+                configMap:
+                  name: claude-settings-profiles
             containers:
               - (name): "?*"
                 env:
@@ -84,6 +87,9 @@ spec:
                     readOnly: true
                   - name: claude-mcp-config
                     mountPath: /etc/mcp
+                    readOnly: true
+                  - name: claude-settings-profiles
+                    mountPath: /etc/claude/settings
                     readOnly: true
     - name: inject-read-config
       match:
@@ -116,6 +122,9 @@ spec:
               - name: claude-mcp-config
                 configMap:
                   name: claude-mcp-config
+              - name: claude-settings-profiles
+                configMap:
+                  name: claude-settings-profiles
             containers:
               - (name): "?*"
                 env:
@@ -152,4 +161,7 @@ spec:
                     readOnly: true
                   - name: claude-mcp-config
                     mountPath: /etc/mcp
+                    readOnly: true
+                  - name: claude-settings-profiles
+                    mountPath: /etc/claude/settings
                     readOnly: true


### PR DESCRIPTION
## Summary
- Add `deniedMcpServers` settings profiles as individual JSON files with IDE schema support
- Bundle into ConfigMap via `configMapGenerator` and mount at `/etc/claude/settings/` by Kyverno
- Agents select profile via n8n Additional Arguments: `--settings /etc/claude/settings/sre.json`

## Linked Issue
Closes #872

## Changes
- **New**: `cluster/apps/claude-agents-shared/base/settings/{sre,dev,minimal,full,generic}.json` — profile files with `$schema` for intellisense
- **Modified**: `cluster/apps/claude-agents-shared/base/kustomization.yaml` — added `configMapGenerator` with `disableNameSuffixHash: true`
- **Modified**: `cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml` — added `claude-settings-profiles` volume + mount to both write and read rules
- **Modified**: `cluster/apps/claude-agents-shared/README.md` — updated structure tree and added Settings Profiles documentation

## Testing
- `kubectl kustomize` builds cleanly with all 5 profile keys in ConfigMap
- All pre-commit hooks passed
- QA validator approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)