### PR TITLE
docs(cluster): review all documentation and workloads for accuracy

### DIFF
--- a/cluster/apps/brave-search-mcp/brave-search-mcp/README.md
+++ b/cluster/apps/brave-search-mcp/brave-search-mcp/README.md
@@ -31,7 +31,7 @@ kubectl logs -n brave-search-mcp -l app.kubernetes.io/name=brave-search-mcp
 ## Access
 
 - **In-cluster only**: `http://brave-search-mcp.brave-search-mcp.svc:8000/mcp`
-- **Network policies**: Ingress from claude-agents-read and claude-agents-write namespaces only; egress to api.search.brave.com only
+- **Network policies**: Ingress from claude-agents-read, claude-agents-write, and coder-system namespaces; egress to api.search.brave.com only
 
 ## Troubleshooting
 

--- a/cluster/apps/cert-manager/cert-manager/README.md
+++ b/cluster/apps/cert-manager/cert-manager/README.md
@@ -18,7 +18,6 @@ cert-manager is a native Kubernetes certificate management controller that autom
 ## Prerequisites
 
 - Kubernetes cluster with Flux CD installed
-- Ingress controller configured
 - DNS records properly configured for domains
 - Cluster issuer credentials available
 
@@ -102,18 +101,6 @@ flux reconcile kustomization cert-manager --with-source
 
 # Update existing issuer using Flux
 flux reconcile kustomization cert-manager --with-source
-```
-
-### Backups
-
-```bash
-# Backup cert-manager configuration
-kubectl get clusterissuers -o yaml > cert-manager-clusterissuers-backup.yaml
-kubectl get certificates -A -o yaml > cert-manager-certificates-backup.yaml
-
-# Restore from backup
-kubectl apply -f cert-manager-clusterissuers-backup.yaml
-kubectl apply -f cert-manager-certificates-backup.yaml
 ```
 
 ## References

--- a/cluster/apps/cloudflare-system/cloudflared/README.md
+++ b/cluster/apps/cloudflare-system/cloudflared/README.md
@@ -54,12 +54,11 @@ kubectl exec -n cloudflare-system deploy/cloudflared -- cloudflared tunnel metri
 3. **Configuration updates**:
 
 ```bash
-# Update cloudflared configuration
-kubectl apply -f updated-values.yaml
+# Reconcile cloudflared configuration changes
+flux reconcile kustomization cloudflared --with-source
 
 # Restart cloudflared
 kubectl rollout restart deploy/cloudflared -n cloudflare-system
-
 ```
 
 ## Troubleshooting
@@ -88,9 +87,8 @@ kubectl rollout restart deploy/cloudflared -n cloudflare-system
 ### Updates
 
 ```bash
-# Update cloudflared
-helm repo update
-helm upgrade cloudflared cloudflare/cloudflared -n cloudflare-system -f values.yaml
+# Update cloudflared using Flux (uses app-template OCIRepository, not a Cloudflare Helm chart)
+flux reconcile kustomization cloudflared --with-source
 ```
 
 ### Tunnel Management
@@ -98,9 +96,6 @@ helm upgrade cloudflared cloudflare/cloudflared -n cloudflare-system -f values.y
 ```bash
 # Check tunnel status
 kubectl exec -n cloudflare-system deploy/cloudflared -- cloudflared tunnel list
-
-# Update tunnel configuration
-kubectl apply -f updated-cloudflared-values.yaml
 ```
 
 ## References

--- a/cluster/apps/cnpg-system/cnpg-operator/README.md
+++ b/cluster/apps/cnpg-system/cnpg-operator/README.md
@@ -95,9 +95,8 @@ kubectl get pods -A -l cluster-name=<cluster-name>
 ### Updates
 
 ```bash
-# Update CNPG operator
-helm repo update
-helm upgrade cnpg-operator cloudnative-pg/cloudnative-pg -n cnpg-system -f values.yaml
+# Update CNPG operator using Flux
+flux reconcile kustomization cnpg-operator --with-source
 ```
 
 ### Database Management

--- a/cluster/apps/cnpg-system/plugin-barman-cloud/README.md
+++ b/cluster/apps/cnpg-system/plugin-barman-cloud/README.md
@@ -7,7 +7,8 @@ Barman Cloud Plugin provides cloud storage integration for PostgreSQL backups ma
 ## Prerequisites
 
 - Kubernetes cluster with Flux CD installed
-- CloudNativePG operator deployed and operational
+- CloudNativePG operator deployed and operational (Flux dependsOn: cnpg-operator)
+- cert-manager deployed and operational (Flux dependsOn: cert-manager)
 - Cloud storage credentials configured (AWS S3, Azure Blob, Google Cloud Storage)
 - Proper network connectivity to cloud storage providers
 

--- a/cluster/apps/discord-mcp/discord-mcp/README.md
+++ b/cluster/apps/discord-mcp/discord-mcp/README.md
@@ -40,7 +40,7 @@ kubectl logs -n discord-mcp -l app.kubernetes.io/name=discord-mcp
 
 2. **MCP connection timeout from agent pods**
    - **Symptom**: Agent reports discord MCP server unavailable
-   - **Resolution**: Check network policies allow ingress from `claude-agents-read` / `claude-agents-write` namespaces on port 8080
+   - **Resolution**: Check network policies allow ingress from `claude-agents-read`, `claude-agents-write`, and `coder-system` namespaces on port 8080
 
 ## References
 

--- a/cluster/apps/external-dns/external-dns-technitium/README.md
+++ b/cluster/apps/external-dns/external-dns-technitium/README.md
@@ -7,7 +7,7 @@ ExternalDNS is a Kubernetes controller that automatically manages DNS records ba
 ## Prerequisites
 
 - Kubernetes cluster with Flux CD installed
-- Technitium DNS server configured and accessible
+- Technitium DNS server deployed and operational (Flux dependsOn: technitium)
 - Proper DNS zone configuration in Technitium
 - API credentials for Technitium DNS server
 - Network connectivity to Technitium DNS server

--- a/cluster/apps/external-secrets/external-secrets/README.md
+++ b/cluster/apps/external-secrets/external-secrets/README.md
@@ -18,9 +18,6 @@ External Secrets Operator manages Kubernetes secrets by synchronizing them from 
 1. **External secret management**:
 
 ```bash
-# Create external secret
-kubectl apply -f externalsecret.yaml
-
 # Check external secret status
 kubectl get externalsecrets -A -o wide
 ```
@@ -41,9 +38,8 @@ kubectl get events -A | grep secretstore
 # Check synchronized secrets
 kubectl get secrets -A
 
-# Check secret data
-kubectl get secret <name> -n <namespace> -o yaml
-
+# Check secret exists (do not output secret data)
+kubectl get secret <name> -n <namespace>
 ```
 
 ## Troubleshooting
@@ -72,17 +68,13 @@ kubectl get secret <name> -n <namespace> -o yaml
 ### Updates
 
 ```bash
-# Update External Secrets Helm chart
-helm repo update
-helm upgrade external-secrets external-secrets/external-secrets -n external-secrets -f values.yaml
+# Update External Secrets using Flux
+flux reconcile kustomization external-secrets --with-source
 ```
 
 ### Secret Store Management
 
 ```bash
-# Update secret store configuration
-kubectl apply -f updated-cluster-secret-store.yaml
-
 # Check secret store status
 kubectl get clustersecretstores -A -o wide
 ```

--- a/cluster/apps/falco-system/falco/README.md
+++ b/cluster/apps/falco-system/falco/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Falco is a cloud-native runtime security tool that monitors system calls to detect anomalous behavior and potential threats. Deployed as high-priority (Tier 2) security observability infrastructure.
+Falco is a cloud-native runtime security tool that monitors system calls to detect anomalous behavior and potential threats. Deployed as high-priority security observability infrastructure.
 
 Components:
 
@@ -23,7 +23,7 @@ Components:
 ```bash
 # Check status
 kubectl get pods -n falco-system
-flux get helmrelease -n flux-system falco
+flux get helmrelease -n falco-system falco
 
 # Force reconcile (GitOps approach)
 flux reconcile kustomization falco --with-source

--- a/cluster/apps/flux-system/flux-instance/README.md
+++ b/cluster/apps/flux-system/flux-instance/README.md
@@ -7,6 +7,7 @@ Flux is a GitOps continuous delivery solution that automates the deployment and 
 ## Prerequisites
 
 - Kubernetes cluster with proper RBAC configured
+- flux-operator deployed and operational (Flux dependsOn: flux-operator)
 - Git repository accessible from cluster
 - SSH keys or credentials for Git access
 - Proper network connectivity to Git repository
@@ -38,11 +39,11 @@ flux reconcile kustomization <name> --with-source
 3. **Drift detection**:
 
    ```bash
-   # Check for drift
-   flux get status --watch
+   # Check all kustomizations for drift
+   flux get kustomizations -A
 
-   # Force reconciliation
-   flux reconcile --all
+   # Force reconciliation of a specific kustomization
+   flux reconcile kustomization <name> --with-source
    ```
 
 ### Validation
@@ -61,7 +62,7 @@ flux get kustomizations -A
 # Expected: Kustomizations listed with ready status
 
 # Validate drift detection
-flux get status --watch
+flux get kustomizations -A
 
 # Expected: No drift detected or reconciliation in progress
 ```
@@ -92,17 +93,13 @@ flux get status --watch
 ### Updates
 
 ```bash
-# Update Flux Helm chart
-helm repo update
-helm upgrade flux fluxcd/flux -n flux-system -f values.yaml
+# Update Flux instance using Flux (uses OCIRepository, not a Helm repo)
+flux reconcile kustomization flux-instance --with-source
 ```
 
 ### GitOps Management
 
 ```bash
-# Force full reconciliation
-flux reconcile --all
-
 # Check Flux version
 flux version
 ```

--- a/cluster/apps/flux-system/flux-operator/README.md
+++ b/cluster/apps/flux-system/flux-operator/README.md
@@ -7,9 +7,6 @@ Flux Operator is a Kubernetes operator that manages Flux deployments using custo
 ## Prerequisites
 
 - Kubernetes cluster with proper RBAC configured
-- Git repository accessible from cluster
-- SSH keys or credentials for Git access
-- Proper network connectivity to Git repository
 
 ## Operation
 

--- a/cluster/apps/flux-system/flux-operator/README.md
+++ b/cluster/apps/flux-system/flux-operator/README.md
@@ -10,7 +10,6 @@ Flux Operator is a Kubernetes operator that manages Flux deployments using custo
 - Git repository accessible from cluster
 - SSH keys or credentials for Git access
 - Proper network connectivity to Git repository
-- Flux instance already deployed
 
 ## Operation
 

--- a/cluster/apps/foundryvtt/foundryvtt/README.md
+++ b/cluster/apps/foundryvtt/foundryvtt/README.md
@@ -192,7 +192,7 @@ Monitor and adjust based on usage:
 
 - **Memory**: Increase NODE_OPTIONS --max-old-space-size for large worlds
 - **CPU**: Adjust UV_THREADPOOL_SIZE based on concurrent users
-- **Storage**: Monitor disk usage: `kubectl exec -n foundryvtt foundryvtt-0 -- df -h /data`
+- **Storage**: Monitor disk usage via PVC: `kubectl get pvc -n foundryvtt`
 
 ## References
 

--- a/cluster/apps/foundryvtt/foundryvtt/README.md
+++ b/cluster/apps/foundryvtt/foundryvtt/README.md
@@ -12,7 +12,7 @@ This deployment runs Foundry VTT in a Kubernetes cluster using Flux for GitOps m
 
 - **Namespace**: `foundryvtt` (created via `namespace.yaml`)
 - **Secrets**: `foundryvtt-secrets` containing Foundry VTT license key and other sensitive configuration
-- **Storage**: Ceph RBD storage class `rbd-fast` with 10Gi PVC for persistent data
+- **Storage**: Ceph RBD storage class `rbd-fast-delete` with 10Gi PVC for persistent data
 - **Dependencies**:
   - Flux for GitOps deployment management
   - cert-manager for TLS certificate management
@@ -80,8 +80,8 @@ flux get kustomizations foundryvtt -n flux-system
 **Diagnosis**:
 
 ```bash
-kubectl logs foundryvtt-0 -n foundryvtt --previous
-kubectl describe pod foundryvtt-0 -n foundryvtt
+kubectl logs -n foundryvtt -l app.kubernetes.io/name=foundryvtt --previous
+kubectl describe deployment foundryvtt -n foundryvtt
 ```
 
 **Common Causes**:
@@ -121,7 +121,7 @@ kubectl describe certificate foundryvtt-<domain>-tls -n foundryvtt
 
 ```bash
 kubectl top pods -n foundryvtt
-kubectl describe pod foundryvtt-0 -n foundryvtt | grep -A 10 "Containers:"
+kubectl describe deployment foundryvtt -n foundryvtt | grep -A 10 "Containers:"
 ```
 
 **Resolution**:
@@ -144,7 +144,7 @@ nslookup foundryvtt.${EXTERNAL_DOMAIN}
 **Resolution**:
 
 - Verify external-dns annotations on ingress routes
-- Check Traefik deployment: `kubectl get pods -n traefik-system`
+- Check Traefik deployment: `kubectl get pods -n traefik`
 - Confirm DNS propagation
 
 ## Maintenance
@@ -170,11 +170,11 @@ Foundry VTT updates are managed through Renovate. Major version updates should b
 
 ```bash
 # Check current version
-kubectl get pod foundryvtt-0 -n foundryvtt -o jsonpath='{.spec.containers[0].image}'
+kubectl get pods -n foundryvtt -l app.kubernetes.io/name=foundryvtt -o jsonpath='{.items[0].spec.containers[0].image}'
 
 # Update via Renovate PR or manual values.yaml change
 # Test after update
-kubectl logs foundryvtt-0 -n foundryvtt | grep "Foundry Virtual Tabletop"
+kubectl logs -n foundryvtt -l app.kubernetes.io/name=foundryvtt | grep "Foundry Virtual Tabletop"
 ```
 
 ### Log Rotation
@@ -183,7 +183,7 @@ Application logs are managed by Kubernetes. For extended retention:
 
 ```bash
 # Export logs for analysis
-kubectl logs foundryvtt-0 -n foundryvtt --since=24h > foundryvtt-logs.txt
+kubectl logs -n foundryvtt -l app.kubernetes.io/name=foundryvtt --since=24h > foundryvtt-logs.txt
 ```
 
 ### Performance Tuning

--- a/cluster/apps/github-mcp/github-mcp-server/README.md
+++ b/cluster/apps/github-mcp/github-mcp-server/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-GitHub MCP (Model Context Protocol) server that provides GitHub API access to Claude agents. It uses a read-tier GitHub App installation token for all API operations (issues, PRs, code search, repository contents). The server runs in HTTP transport mode on port 8082 inside the `github-mcp` namespace and is accessible only to permitted workloads via Cilium network policies.
+GitHub MCP (Model Context Protocol) server that provides GitHub API access to Claude agents. It uses a read-tier GitHub App installation token for all API operations (issues, PRs, code search, repository contents). The server uses a two-container architecture: the `app` container (github-mcp-server) runs on port 8083, while a `auth-proxy` container (Caddy) handles API key authentication and exposes port 8082 via the Kubernetes Service. Accessible only to permitted workloads via Cilium network policies.
 
 The read-tier token is synced from `github-system` by an ESO ExternalSecret and refreshed whenever `github-token-rotation` runs.
 
@@ -21,7 +21,7 @@ The read-tier token is synced from `github-system` by an ESO ExternalSecret and 
 ```bash
 # Check deployment and pod status
 kubectl get pods -n github-mcp
-flux get helmrelease -n flux-system github-mcp-server
+flux get helmrelease -n github-mcp github-mcp-server
 
 # Force reconcile
 flux reconcile kustomization github-mcp-server --with-source

--- a/cluster/apps/kube-system/cilium/README.md
+++ b/cluster/apps/kube-system/cilium/README.md
@@ -43,9 +43,6 @@ kubectl get nodes -o wide
 1. **Network policy management**:
 
 ```bash
-# Apply network policy
-kubectl apply -f network-policy.yaml
-
 # Check network policies
 kubectl get networkpolicies -A
 ```
@@ -96,33 +93,15 @@ kubectl get ciliumloadbalancerippools -n kube-system
 ### Updates
 
 ```bash
-# Update Cilium Helm chart
-helm repo update
-helm upgrade cilium cilium/cilium -n kube-system -f values.yaml
+# Update Cilium using Flux
+flux reconcile kustomization cilium --with-source
 ```
 
 ### BGP Management
 
 ```bash
-# Update BGP configuration
-kubectl apply -f updated-bgp-config.yaml
-
 # Check BGP route advertisements
 kubectl get bgpadvertisements -n kube-system -o wide
-```
-
-### Backups
-
-```bash
-# Backup Cilium configuration
-kubectl get bgppeers -n kube-system -o yaml > cilium-bgp-peers-backup.yaml
-kubectl get bgpadvertisements -n kube-system -o yaml > cilium-bgp-ads-backup.yaml
-kubectl get ciliumnetworkpolicies -A -o yaml > cilium-network-policies-backup.yaml
-
-# Restore from backup
-kubectl apply -f cilium-bgp-peers-backup.yaml
-kubectl apply -f cilium-bgp-ads-backup.yaml
-kubectl apply -f cilium-network-policies-backup.yaml
 ```
 
 ## References

--- a/cluster/apps/kube-system/snapshot-controller/README.md
+++ b/cluster/apps/kube-system/snapshot-controller/README.md
@@ -18,9 +18,6 @@ Snapshot Controller provides Kubernetes-native volume snapshot capabilities, ena
 1. **Volume snapshot management**:
 
 ```bash
-# Create volume snapshot
-kubectl apply -f volumesnapshot.yaml
-
 # Check snapshot status
 kubectl get volumesnapshots -A
 ```
@@ -30,17 +27,11 @@ kubectl get volumesnapshots -A
 ```bash
 # Check snapshot classes
 kubectl get volumesnapshotclasses
-
-# Create snapshot class
-kubectl apply -f volumesnapshotclass.yaml
 ```
 
 3. **Restore operations**:
 
 ```bash
-# Create volume from snapshot
-kubectl apply -f pvc-from-snapshot.yaml
-
 # Check restore status
 kubectl get pvc -A
 ```
@@ -71,8 +62,8 @@ kubectl get pvc -A
 ### Updates
 
 ```bash
-# Update snapshot controller
-kubectl apply -k . --force
+# Update snapshot controller using Flux
+flux reconcile kustomization snapshot-controller --with-source
 ```
 
 ### Snapshot Management

--- a/cluster/apps/kubectl-mcp/kubectl-mcp-server/README.md
+++ b/cluster/apps/kubectl-mcp/kubectl-mcp-server/README.md
@@ -18,7 +18,7 @@ MCP (Model Context Protocol) server providing AI assistants with access to Kuber
 ```bash
 # Check status
 kubectl get pods -n kubectl-mcp
-flux get helmrelease -n flux-system kubectl-mcp-server
+flux get helmrelease -n kubectl-mcp kubectl-mcp-server
 
 # Force reconcile (GitOps approach)
 flux reconcile kustomization kubectl-mcp-server --with-source
@@ -30,7 +30,7 @@ kubectl logs -n kubectl-mcp -l app.kubernetes.io/name=kubectl-mcp-server
 ## Access
 
 - **Traefik ingress**: LAN-only via `kubectl-mcp.lan.${EXTERNAL_DOMAIN}`, requires `X-API-KEY` header
-- **Network policies**: Ingress allowed from Traefik only; egress allowed to kube-apiserver only
+- **Network policies**: Ingress allowed from Traefik, claude-agents-write, claude-agents-read, and coder-system namespaces; egress allowed to kube-apiserver only
 - **RBAC scope**: Read-only access to most resources (including pod logs). Limited writes: pods (delete, eviction), deployments/statefulsets scale subresource only. Cordon/drain/taint/restart/job-creation fall back to local kubectl.
 
 ## Troubleshooting

--- a/cluster/apps/kubelet-csr-approver/kubelet-csr-approver/README.md
+++ b/cluster/apps/kubelet-csr-approver/kubelet-csr-approver/README.md
@@ -92,9 +92,8 @@ kubectl logs -n kubelet-csr-approver deploy/kubelet-csr-approver
 ### Updates
 
 ```bash
-# Update kubelet CSR approver
-helm repo update
-helm upgrade kubelet-csr-approver kubelet-csr-approver/kubelet-csr-approver -n kubelet-csr-approver -f values.yaml
+# Update kubelet CSR approver using Flux
+flux reconcile kustomization kubelet-csr-approver --with-source
 ```
 
 ### CSR Management

--- a/cluster/apps/kyverno/kyverno/README.md
+++ b/cluster/apps/kyverno/kyverno/README.md
@@ -4,7 +4,7 @@
 
 Kyverno is a Kubernetes-native policy engine that validates, mutates, and generates resources. It runs as an admission controller, intercepting API requests to enforce policies without requiring a separate policy language.
 
-In this homelab, Kyverno is deployed as critical infrastructure (Tier 1) with four controllers:
+In this homelab, Kyverno is deployed as critical-infrastructure with four controllers:
 
 - **Admission Controller** - Validates/mutates resources during API requests
 - **Background Controller** - Processes existing resources and generate rules
@@ -25,7 +25,7 @@ In this homelab, Kyverno is deployed as critical infrastructure (Tier 1) with fo
 kubectl get pods -n kyverno
 
 # Check HelmRelease status
-flux get helmrelease -n flux-system kyverno
+flux get helmrelease -n kyverno kyverno
 
 # Force reconcile
 flux reconcile kustomization kyverno --with-source

--- a/cluster/apps/kyverno/policies/README.md
+++ b/cluster/apps/kyverno/policies/README.md
@@ -72,6 +72,35 @@ spec:
 
 Current overrides: cilium (`timeout: 2m`), n8n/rook-ceph-cluster (`timeout: 15m`).
 
+### inject-claude-agent-config
+
+Injects configuration into Claude agent pods spawned by n8n, including GitHub bot credentials (gh CLI config, SSH key, gitconfig), MCP server config, and environment variables. Applies to pods with the `managed-by: n8n-claude-code` label in `claude-agents-write` and `claude-agents-read` namespaces. Write and read namespaces receive the same volume mounts and environment variables, with OAuth scopes differentiated via ESO key mapping.
+
+**Injected Resources:**
+
+| Type | Name | Purpose |
+| ---- | ---- | ------- |
+| Secret volume | `github-bot-credentials` | gh CLI hosts.yml |
+| Secret volume | `github-bot-ssh-key` | Git SSH key |
+| ConfigMap volume | `github-bot-gitconfig` | Global gitconfig |
+| ConfigMap volume | `claude-mcp-config` | MCP server configuration |
+| ConfigMap volume | `claude-settings-profiles` | Claude settings profiles |
+| Env (secret) | `CONTEXT7_API_KEY` | Context7 MCP API key |
+| Env (secret) | `HA_API_KEY` | Home Assistant MCP API key |
+| Env (secret) | `SRE_MCP_AUTH_TOKEN` | SRE MCP auth token |
+
+### add-pss-restricted-defaults
+
+Mutates incoming Pods to add security context fields required for Pod Security Standards (PSS) Restricted profile compliance. Only sets fields that are not already defined, preserving app-specific configurations. Adds `seccompProfile: RuntimeDefault`, `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, and drops all capabilities on containers and init containers.
+
+**Excluded Namespaces:** kube-system, kube-public, kube-node-lease, flux-system, kyverno, rook-ceph, falco-system, irq-balance, spegel, velero, observability, nut-system, dev-debug
+
+### add-default-topology-spread
+
+Automatically injects topology spread constraints on Deployments and StatefulSets that don't already have them. Uses soft constraints (`ScheduleAnyway`) with `maxSkew: 1` to ensure balanced pod distribution across nodes without blocking scheduling. Matches on `app.kubernetes.io/name` label for the label selector.
+
+**Excluded Namespaces:** kube-system, kube-public, kube-node-lease, flux-system, kyverno
+
 ## Operation
 
 ### Key Commands

--- a/cluster/apps/minecraft/bedrock-connect/README.md
+++ b/cluster/apps/minecraft/bedrock-connect/README.md
@@ -1,8 +1,8 @@
-# Minecraft Bedrock Connect - Cross-Platform Bridge
+# Minecraft Bedrock Connect - Server List Tool
 
 ## Overview
 
-Minecraft Bedrock Connect is a proxy service that enables cross-platform play between Minecraft Bedrock Edition and Java Edition. In the spruyt-labs homelab, this service allows players on different platforms to connect and play together seamlessly.
+Minecraft Bedrock Connect is a DNS redirect and server list tool that allows Minecraft Bedrock Edition players on consoles (Xbox, PlayStation, Switch) to connect to third-party servers. It works by redirecting DNS queries for featured servers to the Bedrock Connect server, which presents a custom server list UI. In the spruyt-labs homelab, this enables console players to join self-hosted Minecraft servers that aren't on the official featured server list.
 
 ## Prerequisites
 

--- a/cluster/apps/mosquitto/mosquitto/README.md
+++ b/cluster/apps/mosquitto/mosquitto/README.md
@@ -8,9 +8,7 @@ Mosquitto is an open-source MQTT broker that implements the MQTT protocol for li
 
 - Kubernetes cluster with Flux CD installed
 - Storage class configured for persistent volumes
-- Ingress controller configured for MQTT protocol
 - TLS certificates available for secure MQTT connections
-- Rook Ceph storage provisioned (dependency)
 
 ## Operation
 

--- a/cluster/apps/n8n-system/n8n/README.md
+++ b/cluster/apps/n8n-system/n8n/README.md
@@ -7,10 +7,8 @@ n8n is a workflow automation tool that connects various applications and service
 ## Prerequisites
 
 - Kubernetes cluster with Flux CD installed
-- PostgreSQL operator (CNPG) deployed
-- Storage class configured for persistent volumes
-- Ingress controller configured
-- TLS certificates available
+- CNPG operator deployed (dependency)
+- Barman Cloud plugin deployed (dependency)
 - Authentik deployed (dependency)
 - Valkey deployed (dependency)
 - Claude agents write deployed (dependency)

--- a/cluster/apps/n8n-system/n8n/README.md
+++ b/cluster/apps/n8n-system/n8n/README.md
@@ -11,7 +11,9 @@ n8n is a workflow automation tool that connects various applications and service
 - Storage class configured for persistent volumes
 - Ingress controller configured
 - TLS certificates available
-- Rook Ceph storage provisioned (dependency)
+- Authentik deployed (dependency)
+- Valkey deployed (dependency)
+- Claude agents write deployed (dependency)
 
 ## Operation
 
@@ -99,7 +101,7 @@ N8N Community Edition doesn't support OAuth2 natively. SSO is implemented via Au
 ### How It Works
 
 1. User navigates to `https://n8n.${EXTERNAL_DOMAIN}`
-2. Traefik's forwardAuth middleware calls Authentik's embedded outpost
+2. Traefik's forwardAuth middleware calls Authentik's standalone outpost
 3. Authentik authenticates user and injects `X-authentik-email` header
 4. N8N's external hooks (`hooks.js`) read the header and issue a session cookie
 5. User is logged in with their pre-provisioned N8N account

--- a/cluster/apps/observability/victoria-logs-single/README.md
+++ b/cluster/apps/observability/victoria-logs-single/README.md
@@ -37,14 +37,14 @@ kubectl top pods -n observability --selector=app.kubernetes.io/name=victoria-log
 
 **Diagnosis**:
 
-- Verify fluent-bit or vector sidecar injection
+- Verify the separate vector deployment is running and collecting logs
 - Check log collection annotations on application pods
 - Review network policies for observability namespace
 
 **Resolution**:
 
 1. Add required annotations to application deployments
-2. Verify sidecar container status in application pods
+2. Verify the vector deployment status in the observability namespace
 3. Check Cilium network policies for log collection traffic
 
 #### Symptom: High storage usage or retention issues

--- a/cluster/apps/observability/victoria-metrics-k8s-stack/README.md
+++ b/cluster/apps/observability/victoria-metrics-k8s-stack/README.md
@@ -7,6 +7,9 @@ Victoria Metrics k8s stack provides comprehensive monitoring, alerting, and visu
 ## Preconditions
 
 - Kubernetes cluster operational with FluxCD reconciliation active
+- victoria-metrics-operator (dependsOn)
+- external-secrets (dependsOn)
+- authentik (dependsOn)
 - Storage class configured for persistent volume claims
 - Network connectivity between observability namespace and other cluster components
 - Appropriate RBAC permissions for service accounts
@@ -79,8 +82,8 @@ kubectl get deployment -n observability victoria-metrics-k8s-stack -o json | jq 
 # Test metrics endpoint
 kubectl exec -n observability <victoria-metrics-pod> -- curl -s "http://localhost:8428/api/v1/query?query=up"
 
-# Check alertmanager configuration
-kubectl get secret -n observability victoria-metrics-k8s-stack-alertmanager -o yaml
+# Check alertmanager secret exists
+kubectl get secret -n observability victoria-metrics-k8s-stack-alertmanager
 ```
 
 ## Escalation

--- a/cluster/apps/observability/victoria-metrics-operator/README.md
+++ b/cluster/apps/observability/victoria-metrics-operator/README.md
@@ -20,7 +20,7 @@ Victoria Metrics Operator manages the lifecycle of VictoriaMetrics custom resour
 kubectl get pods -n observability --selector=app.kubernetes.io/name=victoria-metrics-operator
 
 # Verify CRD status
-kubectl get crd victoriametrics.victoriametrics.com -o yaml
+kubectl get crd vmsingles.operator.victoriametrics.com vmagents.operator.victoriametrics.com
 
 # Check operator logs
 kubectl logs -n observability -l app.kubernetes.io/name=victoria-metrics-operator --tail=50
@@ -78,18 +78,6 @@ kubectl get deployment -n observability victoria-metrics-operator -o json | jq '
 
 # Check operator conditions
 kubectl get pods -n observability -l app.kubernetes.io/name=victoria-metrics-operator -o json | jq '.items[0].status.conditions'
-
-# Test CRD creation
-kubectl apply -f - <<EOF
-apiVersion: operator.victoriametrics.com/v1beta1
-kind: VMCluster
-metadata:
-  name: test-cluster
-  namespace: observability
-spec:
-  retentionPeriod: "1"
-  replicaCount: 1
-EOF
 ```
 
 ## Escalation

--- a/cluster/apps/observability/victoria-metrics-secret-writer/README.md
+++ b/cluster/apps/observability/victoria-metrics-secret-writer/README.md
@@ -1,119 +1,63 @@
-# Victoria Metrics Secret Writer
+# Victoria Metrics Secret Writer - etcd TLS Certificate Provisioner
 
-## Summary
+## Overview
 
-Victoria Metrics Secret Writer automates the creation and management of Kubernetes secrets containing VictoriaMetrics configuration, credentials, and sensitive data. This component ensures secure and automated secret provisioning for the observability stack.
+One-shot Kubernetes Job that copies etcd TLS certificates from the host filesystem into a Kubernetes secret (`etcd-secrets`) in the `observability` namespace. This enables VictoriaMetrics to scrape etcd metrics over TLS.
 
-## Preconditions
+**Priority**: standard
 
-- Kubernetes cluster with FluxCD active
-- RBAC permissions for secret creation and management
-- Service account with appropriate permissions
-- Target namespaces exist for secret deployment
+> **Note**: This is a Job (not a Deployment). It runs once, copies the certs, and exits. To re-run, delete the completed Job and reconcile.
+
+## Prerequisites
+
+- Kubernetes cluster with Flux CD
+- Control plane nodes with etcd TLS certificates at `/system/secrets/etcd/`
+
+## Architecture
+
+The Job:
+
+1. Schedules on a control plane node (nodeAffinity + toleration)
+2. Mounts `/system/secrets/etcd` via hostPath
+3. Uses `bitnami/kubectl` to create/update the `etcd-secrets` secret from `ca.crt`, `server.crt`, and `server.key`
+4. Runs as the `secrets-writer` ServiceAccount with a Role scoped to secrets CRUD in the `observability` namespace
 
 ## Operation
 
-### Monitoring Commands
+### Key Commands
 
 ```bash
-# Check secret writer deployment
-kubectl get pods -n observability --selector=app.kubernetes.io/name=victoria-metrics-secret-writer
+# Check Job status
+kubectl get jobs -n observability etcd-secret-writer
 
-# Verify service account
-kubectl get sa -n observability victoria-metrics-secret-writer
+# Check if the secret was created
+kubectl get secret -n observability etcd-secrets
 
-# Check RBAC permissions
-kubectl get role,rolebinding -n observability | grep victoria-metrics
+# Force re-run (delete completed Job, then reconcile)
+kubectl delete job -n observability etcd-secret-writer
+flux reconcile kustomization victoria-metrics-secret-writer --with-source
 
-# Monitor secret creation
-kubectl get secrets -A --field-selector=type=victoriametrics.com/managed
+# View Job logs
+kubectl logs -n observability -l job-name=etcd-secret-writer
 ```
 
 ## Troubleshooting
 
 ### Common Issues
 
-#### Symptom: Secrets not being created
+1. **Job stuck in Pending**
+   - **Symptom**: Pod not scheduled
+   - **Resolution**: Verify control plane node has the `node-role.kubernetes.io/control-plane` label and the toleration is correct
 
-**Diagnosis**:
+2. **Job fails with permission denied**
+   - **Symptom**: Pod logs show RBAC or filesystem errors
+   - **Resolution**: Check `secrets-writer` ServiceAccount, Role, and RoleBinding exist in `observability` namespace. Verify etcd certs are readable at `/system/secrets/etcd/` on control plane nodes.
 
-- Check secret writer logs for permission errors
-- Verify service account RBAC configuration
-- Review target namespace existence and accessibility
-
-**Resolution**:
-
-1. Validate service account permissions with `kubectl auth can-i`
-2. Check target namespace labels and annotations
-3. Review secret writer configuration in values.yaml
-
-#### Symptom: Secret content malformed or incomplete
-
-**Diagnosis**:
-
-- Examine secret writer logs for template errors
-- Verify input data sources and templates
-- Check for missing or incorrect values in configuration
-
-**Resolution**:
-
-1. Validate template syntax in configuration
-2. Check source data availability and format
-3. Review secret structure requirements
-
-## Validation
-
-### Expected Outcomes
-
-1. **Deployment Success**: Secret writer pod shows `Running` status
-2. **RBAC Functional**: Service account has required permissions
-3. **Secret Creation**: Target secrets created with correct structure
-4. **Content Validation**: Secrets contain expected VictoriaMetrics configuration
-
-### Validation Commands
-
-```bash
-# Verify deployment status
-kubectl get deployment -n observability victoria-metrics-secret-writer -o json | jq '.status.availableReplicas'
-
-# Check service account permissions
-kubectl auth can-i create secrets --as=system:serviceaccount:observability:victoria-metrics-secret-writer
-
-# Validate secret creation
-kubectl get secrets -n <target-namespace> --field-selector=type=victoriametrics.com/managed
-
-# Check secret content structure
-kubectl get secret -n <target-namespace> <secret-name> -o json | jq '.data | keys'
-```
-
-## Escalation
-
-- **RBAC Issues**: Contact security team for permission troubleshooting
-- **Secret Format Problems**: Engage observability team for configuration
-- **Template Errors**: Consult with Helm maintainers for syntax
-- **Namespace Access**: Escalate to cluster administrators for cross-namespace permissions
-
-## Maintenance
-
-### Updates
-
-1. Review secret structure changes in new versions
-2. Test template updates in staging environment
-3. Update values.yaml for new secret requirements
-
-### Backups
-
-1. Secret content managed by Git and Flux
-2. Configuration backed up via Velero
-3. Verify backup status: `velero get backups | grep observability`
+3. **Secret not updated after cert rotation**
+   - **Symptom**: `etcd-secrets` contains stale certificates
+   - **Resolution**: Delete the completed Job and reconcile to re-run it
 
 ## References
 
-- [VictoriaMetrics Documentation](https://docs.victoriametrics.com/)
-- [Kubernetes Secrets Best Practices](https://kubernetes.io/docs/concepts/configuration/secret/)
-- [RBAC for Service Accounts](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
-- [Helm Secret Management Patterns](https://helm.sh/docs/chart_best_practices/values/)
-
-## Change History
-
-- **2025-12-04**: Initial documentation created during documentation maintenance workflow
+- [VictoriaMetrics etcd Monitoring](https://docs.victoriametrics.com/)
+- [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)

--- a/cluster/apps/qdrant-system/qdrant/README.md
+++ b/cluster/apps/qdrant-system/qdrant/README.md
@@ -11,6 +11,7 @@ Qdrant is a high-performance vector similarity search engine and vector database
 - Network connectivity for search operations
 - Proper resource allocation for vector computations
 - Monitoring for performance metrics
+- Kyverno deployed (dependency - required for init container policies)
 
 ### Validation
 

--- a/cluster/apps/redisinsight/redisinsight/README.md
+++ b/cluster/apps/redisinsight/redisinsight/README.md
@@ -7,10 +7,12 @@ RedisInsight is a powerful visualization and management tool for Redis databases
 ## Prerequisites
 
 - Kubernetes cluster with Flux CD installed
-- Redis or Valky instances available
+- Redis or Valkey instances available
 - Network connectivity between RedisInsight and data stores
 - Proper RBAC permissions for monitoring
 - Browser access for web interface
+- Authentik deployed (dependency)
+- Valkey deployed (dependency)
 
 ## Operation
 
@@ -88,12 +90,11 @@ kubectl get helmreleases -n redisinsight
 
 ### Database Management
 
-```bash
-# Add new database connection
-kubectl apply -f new-database-config.yaml
+Database connections are managed through the RedisInsight web UI or via values.yaml configuration. Edit the values file and reconcile with Flux:
 
-# Remove database connection
-kubectl delete -f old-database-config.yaml
+```bash
+# Reconcile after configuration changes
+flux reconcile kustomization redisinsight --with-source
 ```
 
 ## References

--- a/cluster/apps/rook-ceph/README.md
+++ b/cluster/apps/rook-ceph/README.md
@@ -12,9 +12,10 @@ Objectives:
 
 ## Current Version
 
-- **Operator Chart Version**: v1.18.7 (rook-ceph)
-- **Cluster Chart Version**: v1.18.7 (rook-ceph-cluster)
-- **Last Updated**: Check `cluster/apps/rook-ceph/rook-ceph-operator/app/release.yaml` and `cluster/apps/rook-ceph/rook-ceph-cluster/app/release.yaml` for current pinned versions
+Chart versions are managed by Renovate and Flux. Check the release files for current pinned versions:
+
+- **Operator**: `cluster/apps/rook-ceph/rook-ceph-operator/app/release.yaml`
+- **Cluster**: `cluster/apps/rook-ceph/rook-ceph-cluster/app/release.yaml`
 
 ## Prerequisites
 

--- a/cluster/apps/rook-ceph/rook-ceph-cluster/README.md
+++ b/cluster/apps/rook-ceph/rook-ceph-cluster/README.md
@@ -76,7 +76,7 @@ Operate the Rook Ceph cluster Helm release to deploy and manage a Ceph storage c
 
    ```bash
    kubectl get cephcluster -n rook-ceph
-   kubectl ceph status
+   kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
    ```
 
 3. Monitor OSD status:
@@ -90,13 +90,13 @@ Operate the Rook Ceph cluster Helm release to deploy and manage a Ceph storage c
 1. Check cluster health:
 
    ```bash
-   kubectl ceph health
+   kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health
    ```
 
 2. View cluster details:
 
    ```bash
-   kubectl ceph cluster status
+   kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
    ```
 
 3. Access toolbox for debugging:
@@ -131,7 +131,7 @@ Operate the Rook Ceph cluster Helm release to deploy and manage a Ceph storage c
 ### Validation
 
 - `kubectl get cephcluster -n rook-ceph` shows healthy Ceph clusters.
-- `kubectl ceph health` reports HEALTH_OK or HEALTH_WARN.
+- `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health` reports HEALTH_OK or HEALTH_WARN.
 - `kubectl get storageclass` shows Ceph storage classes available.
 - `flux get helmrelease rook-ceph-cluster -n rook-ceph` reports `Ready=True` with no pending upgrades.
 
@@ -158,7 +158,7 @@ Operate the Rook Ceph cluster Helm release to deploy and manage a Ceph storage c
 | `task dev-env:lint`                                    | Executes markdownlint, prettier, and ancillary linters to keep documentation compliant.          |
 | `flux diff hr rook-ceph-cluster --namespace rook-ceph` | Previews rendered Helm changes before reconciliation.                                            |
 | `kubectl get cephcluster -n rook-ceph`                 | Validates Ceph cluster deployment.                                                               |
-| `kubectl ceph status`                                  | Ensures cluster health.                                                                          |
+| `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status` | Ensures cluster health.                                                                          |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/cluster/apps/rook-ceph/rook-ceph-operator/README.md
+++ b/cluster/apps/rook-ceph/rook-ceph-operator/README.md
@@ -76,7 +76,7 @@ Operate the Rook Ceph operator Helm release to manage Ceph storage clusters, pro
 
    ```bash
    kubectl get cephcluster -n rook-ceph
-   kubectl ceph status
+   kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
    ```
 
 3. Monitor storage classes:
@@ -90,7 +90,7 @@ Operate the Rook Ceph operator Helm release to manage Ceph storage clusters, pro
 1. Check cluster health:
 
    ```bash
-   kubectl ceph health
+   kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph health
    ```
 
 2. View OSD status:
@@ -158,7 +158,7 @@ Operate the Rook Ceph operator Helm release to manage Ceph storage clusters, pro
 | `task dev-env:lint`                                     | Executes markdownlint, prettier, and ancillary linters to keep documentation compliant.          |
 | `flux diff hr rook-ceph-operator --namespace rook-ceph` | Previews rendered Helm changes before reconciliation.                                            |
 | `kubectl get pods -n rook-ceph`                         | Validates pod deployment and readiness.                                                          |
-| `kubectl ceph status`                                   | Ensures Ceph cluster health.                                                                     |
+| `kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status` | Ensures Ceph cluster health.                                                                     |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -168,4 +168,4 @@ Operate the Rook Ceph operator Helm release to manage Ceph storage clusters, pro
 - Flux control plane operations: [cluster/apps/flux-system/flux-instance/README.md](../../../../cluster/apps/flux-system/flux-instance/README.md)
 - Storage operations: [cluster/apps/README.md](/cluster/apps/README.md)
 - Rook Ceph documentation: <https://rook.io/docs/rook/latest/>
-- Rook Ceph Helm chart: <https://github.com/rook/rook/tree/master/deploy/charts/rook-ceph-cluster>
+- Rook Ceph Helm chart: <https://github.com/rook/rook/tree/master/deploy/charts/rook-ceph>

--- a/cluster/apps/technitium/technitium-secondary/README.md
+++ b/cluster/apps/technitium/technitium-secondary/README.md
@@ -19,10 +19,9 @@ Technitium Secondary is a replica DNS server that provides redundant DNS service
 
 1. **DNS zone synchronization**:
 
-   ```bash
-   # Check zone transfer status
-   kubectl exec -it <technitium-secondary-pod> -n technitium -- technitium check-sync
+   Zone synchronization status is managed through the Technitium web UI or its HTTP API.
 
+   ```bash
    # Monitor zone transfer logs
    kubectl logs -n technitium <technitium-secondary-pod> | grep "transfer"
    ```
@@ -53,9 +52,7 @@ Run the following commands to validate the procedures:
 
 ```bash
 # Validate DNS zone synchronization
-kubectl exec -it <technitium-secondary-pod> -n technitium -- technitium check-sync
-
-# Expected: Synchronization status displayed
+# Use the Technitium web UI or HTTP API to verify sync status
 
 # Validate performance monitoring
 kubectl top pods -n technitium | grep secondary
@@ -105,18 +102,12 @@ kubectl get pods -n technitium --no-headers | grep secondary | grep 'Running'
 flux reconcile kustomization technitium-secondary --with-source
 
 # Check update status
-kubectl get helmreleases -n technitium | grep secondary
+flux get hr -n technitium technitium-secondary
 ```
 
 ### Zone Synchronization
 
-```bash
-# Force zone transfer
-kubectl exec -it <technitium-secondary-pod> -n technitium -- technitium force-sync
-
-# Check synchronization status
-kubectl exec -it <technitium-secondary-pod> -n technitium -- technitium sync-status
-```
+Zone synchronization is managed through the Technitium web UI or its HTTP API. There is no CLI tool for Technitium sync management.
 
 ## References
 

--- a/cluster/apps/technitium/technitium/README.md
+++ b/cluster/apps/technitium/technitium/README.md
@@ -18,10 +18,9 @@ Technitium is a powerful, open-source DNS server that provides authoritative DNS
 
 1. **DNS zone management**:
 
-   ```bash
-   # Check DNS zones
-   kubectl exec -it <technitium-pod> -n technitium -- technitium list-zones
+   DNS zones are managed through the Technitium web UI or its HTTP API. Access the web interface to view and manage zones.
 
+   ```bash
    # Monitor DNS queries
    kubectl logs -n technitium <technitium-pod> | grep "query"
    ```
@@ -52,9 +51,7 @@ Run the following commands to validate the procedures:
 
 ```bash
 # Validate DNS zone management
-kubectl exec -it <technitium-pod> -n technitium -- technitium list-zones
-
-# Expected: DNS zones listed
+# Use the Technitium web UI or HTTP API to verify zones
 
 # Validate performance monitoring
 kubectl top pods -n technitium
@@ -104,18 +101,12 @@ kubectl get pods -n technitium --no-headers | grep 'Running'
 flux reconcile kustomization technitium --with-source
 
 # Check update status
-kubectl get helmreleases -n technitium
+flux get hr -n technitium technitium
 ```
 
 ### Zone Management
 
-```bash
-# Add new DNS zone
-kubectl exec -it <technitium-pod> -n technitium -- technitium add-zone <domain> <zone-file>
-
-# Remove DNS zone
-kubectl exec -it <technitium-pod> -n technitium -- technitium remove-zone <domain>
-```
+DNS zones are managed through the Technitium web UI or its HTTP API. There is no CLI tool for Technitium zone management.
 
 ## References
 

--- a/cluster/apps/traefik/traefik/README.md
+++ b/cluster/apps/traefik/traefik/README.md
@@ -18,9 +18,6 @@ Traefik is a modern HTTP reverse proxy and load balancer that serves as the ingr
 1. **Ingress route management**:
 
 ```bash
-# Add new ingress route
-kubectl apply -f ingress/<workload>/ingress-route.yaml
-
 # Check ingress route status
 kubectl get ingressroutes -A -o wide
 ```
@@ -92,19 +89,8 @@ kubectl port-forward svc/traefik -n traefik 9000:9000
 ### Updates
 
 ```bash
-# Update Traefik Helm chart
-helm repo update
-helm upgrade traefik traefik/traefik -n traefik -f values.yaml
-```
-
-### Ingress Route Management
-
-```bash
-# Add new ingress route
-kubectl apply -f ingress/<workload>/ingress-route.yaml
-
-# Update existing ingress route
-kubectl apply -f ingress/<workload>/updated-ingress-route.yaml
+# Update Traefik using Flux
+flux reconcile kustomization traefik --with-source
 ```
 
 ## References

--- a/cluster/apps/whoami/whoami/README.md
+++ b/cluster/apps/whoami/whoami/README.md
@@ -110,8 +110,8 @@ kubectl get helmreleases -n whoami
 ### Service Management
 
 ```bash
-# Scale service
-kubectl scale deployment whoami -n whoami --replicas=3
+# Scale service: edit replicas in values.yaml, then reconcile
+flux reconcile kustomization whoami --with-source
 
 # Restart service
 kubectl rollout restart deployment whoami -n whoami

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -92,7 +92,7 @@ Renovate automates dependency updates. See [.claude/rules/renovate.md](../.claud
 
 ### Quarterly Maintenance
 
-1. Review all Renovate configuration files in `.github/renovate/`
+1. Review the Renovate configuration file `.github/renovate.json5`
 2. Monitor update success rates and system stability
 3. Audit manager coverage for all dependency types
 

--- a/docs/templates/readme_template.md
+++ b/docs/templates/readme_template.md
@@ -4,7 +4,7 @@
 
 [Brief description of the component, its purpose, and role in the homelab.]
 
-> **Note**: HelmRelease resources are managed by Flux in flux-system namespace but deploy workloads to the target namespace specified in ks.yaml.
+> **Note**: HelmRelease resources are created in the target namespace specified by ks.yaml `targetNamespace`.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@
 ```bash
 # Check status
 kubectl get pods -n [namespace]
-flux get helmrelease -n flux-system [component]
+flux get helmrelease -n [namespace] [component]
 
 # Force reconcile (GitOps approach)
 flux reconcile kustomization [component] --with-source

--- a/docs/workload-classification.md
+++ b/docs/workload-classification.md
@@ -100,7 +100,7 @@ CPU limits protect hardware from thermal throttling caused by unbounded workload
 | Namespace       | Workload                             | Rationale            |
 | --------------- | ------------------------------------ | -------------------- |
 | headlamp-system | headlamp                             | Kubernetes dashboard |
-| minecraft       | minecraft-bedrock-*, bedrock-connect | Gaming servers       |
+| minecraft       | crafty-controller, bedrock-connect   | Gaming servers       |
 | foundryvtt      | foundryvtt                           | Gaming (D&D)         |
 | redisinsight    | redisinsight                         | Redis GUI            |
 | whoami          | whoami                               | Test/debug service   |


### PR DESCRIPTION
## Summary
Comprehensive review of all documentation (`docs/`) and workload READMEs (`cluster/apps/**/README.md`) for accuracy against actual deployed configurations. Fixes 36 files across 3 commits.

## Changes

### Critical Fixes
- **victoria-metrics-secret-writer README** - Complete rewrite. Was entirely fabricated (described non-existent "secret writer deployment"). Actually a one-shot Job copying etcd TLS certs.
- **2 secrets violations removed** - external-secrets and victoria-metrics-k8s-stack had `kubectl get secret -o yaml`

### Docs Fixes
- **maintenance.md** - Renovate config path `.github/renovate/` -> `.github/renovate.json5`
- **workload-classification.md** - Minecraft workloads `minecraft-bedrock-*` -> `crafty-controller`

### Anti-Pattern Removals (10+ READMEs)
Removed `helm upgrade`, `kubectl apply`, and manual backup/restore commands from: cert-manager, cilium, snapshot-controller, cloudflared, external-secrets, flux-instance, traefik, cnpg-operator, kubelet-csr-approver, whoami

### Factual Corrections
- **5 wrong flux namespaces** fixed (kyverno, falco, kubectl-mcp, github-mcp, flux-instance)
- **8 missing dependencies** added (external-dns->technitium, flux-instance->flux-operator, plugin-barman-cloud->cert-manager, n8n->valkey+claude-agents-write, redisinsight->authentik+valkey, qdrant->kyverno, vm-k8s-stack->3 deps)
- **bedrock-connect** - Fixed wrong description (DNS redirect tool, not cross-platform bridge)
- **github-mcp** - Clarified two-container architecture (app:8083, Caddy proxy:8082)
- **foundryvtt** - Fixed storage class (`rbd-fast` -> `rbd-fast-delete`), namespace
- **technitium** (both) - Removed fabricated CLI commands
- **4 network policy descriptions** expanded (kubectl-mcp, github-mcp, brave-search-mcp, discord-mcp)
- **kyverno/policies** - Documented 3 missing policies
- **rook-ceph** - Fixed invalid `kubectl ceph` commands, removed hardcoded versions

### Remaining Notes (not addressed)
- Priority tier is missing from most READMEs (systemic gap, lower priority)
- Several READMEs remain as generic boilerplate (vaultwarden, mosquitto, qdrant) but have no active factual errors after fixes

## Testing
- All changes are documentation-only (*.md files)
- No cluster resources affected
- Verified all referenced file paths exist in the codebase

https://claude.ai/code/session_01JLUFna3Qo95jRudwqwBVJV