### PR TITLE
chore(secrets): sync MCP API keys from traefik via ESO (phase 1)

### DIFF
--- a/.claude/agent-memory/qa-validator/known-patterns.md
+++ b/.claude/agent-memory/qa-validator/known-patterns.md
@@ -10,7 +10,7 @@ MegaLinter or schema check results that are not actual issues.
 | AVD-KSV-0125 on ghcr.io images | Trivy | ghcr.io/siderolabs is the official Talos registry | 2 | 2026-02-28 | 2026-02-28 |
 | AVD-KSV-0048 on intentional write RBAC | Trivy | Expected when Role/ClusterRole intentionally grants write verbs (delete, patch, create) for operational use cases | 7 | 2026-04-02 | 2026-03-15 |
 | AVD-KSV-0053 on intentional pods/exec RBAC | Trivy | Expected when Role grants pods/exec create for spawner/orchestrator patterns (e.g., n8n-claude-spawner). Scoped by Role (not ClusterRole) + PSA restricted namespace | 2 | 2026-04-02 | 2026-03-30 |
-| AVD-KSV-0113 on resourceName-scoped secret access | Trivy | Expected when Role grants secret get scoped to specific resourceNames (e.g., claude-credentials). Not broad secret access | 7 | 2026-04-04 | 2026-03-30 |
+| AVD-KSV-0113 on resourceName-scoped secret access | Trivy | Expected when Role grants secret get scoped to specific resourceNames (e.g., claude-credentials). Not broad secret access | 8 | 2026-04-18 | 2026-03-30 |
 | AVD-KSV-01010 on gitconfig ConfigMaps with email/signingkey | Trivy | Git config contains public bot email and signingkey path, not sensitive data. False positive on keyword match | 3 | 2026-04-02 | 2026-03-31 |
 | AVD-KSV-0125 on alpine/k8s CronJob images | Trivy | alpine/k8s is a trusted community image for kubectl operations. Trivy flags non-standard registries | 3 | 2026-04-04 | 2026-03-31 |
 | tflint terraform_required_version/terraform_required_providers on Coder templates | tflint | Coder provisioner manages Terraform and provider versions. Version constraints in coder/templates/ are optional best-practice, not blocking | 2 | 2026-04-04 | 2026-04-04 |

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -278,6 +278,7 @@ misconfigurations:
     paths:
       - cluster/apps/github-system/github-token-rotation/app/reader-role.yaml
       - cluster/apps/github-system/github-token-rotation/app/role.yaml
+      - cluster/apps/traefik/traefik/app/mcp-auth-reader-rbac.yaml
 
   # ==============================================================================
   # Nexus OSS - provisioning Job

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/README.md
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/README.md
@@ -44,3 +44,4 @@ The following Kubernetes Secrets must exist in `coder-workspaces`:
 - `coder-talosconfig` — Talos client config mounted at `~/.talos/config`
 - `coder-terraform-credentials` — Terraform credentials at `~/.terraform.d/credentials.tfrc.json`
 - `coder-workspace-env` — Env vars injected into pods
+- `coder-workspace-mcp-api-keys` — MCP API keys synced from `traefik/traefik-mcp-api-keys` via ExternalSecret

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
@@ -513,6 +513,13 @@ resource "kubernetes_pod_v1" "main" {
         }
       }
 
+      # MCP API keys synced from traefik ns via ExternalSecret
+      env_from {
+        secret_ref {
+          name = "coder-workspace-mcp-api-keys"
+        }
+      }
+
       resources {
         requests = {
           cpu    = "2000m"

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/README.md
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/README.md
@@ -49,3 +49,4 @@ The following Kubernetes Secrets must exist in `coder-workspaces`:
 - `coder-talosconfig` — Talos client config mounted at `~/.talos/config`
 - `coder-terraform-credentials` — Terraform credentials at `~/.terraform.d/credentials.tfrc.json`
 - `coder-workspace-env` — Env vars injected into pods
+- `coder-workspace-mcp-api-keys` — MCP API keys synced from `traefik/traefik-mcp-api-keys` via ExternalSecret

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/main.tf
@@ -532,6 +532,13 @@ resource "kubernetes_pod_v1" "main" {
         }
       }
 
+      # MCP API keys synced from traefik ns via ExternalSecret
+      env_from {
+        secret_ref {
+          name = "coder-workspace-mcp-api-keys"
+        }
+      }
+
       resources {
         requests = {
           cpu    = "2000m"

--- a/cluster/apps/coder-workspaces/coder-workspaces/app/kustomization.yaml
+++ b/cluster/apps/coder-workspaces/coder-workspaces/app/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./coder-workspace-env.sops.yaml
+  - ./mcp-auth-secret-store.yaml
+  - ./mcp-auth-external.yaml
   - ./coder-talosconfig.sops.yaml
   - ./coder-ssh-signing-key.sops.yaml
   - ./coder-terraform-credentials.sops.yaml

--- a/cluster/apps/coder-workspaces/coder-workspaces/app/mcp-auth-external.yaml
+++ b/cluster/apps/coder-workspaces/coder-workspaces/app/mcp-auth-external.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/external-secrets.io/externalsecret_v1.json
+# Pulls MCP API keys from traefik ns (source of truth) into coder-workspaces.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: coder-workspace-mcp-api-keys
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: SecretStore
+    name: traefik-mcp-api-keys-store
+  target:
+    name: coder-workspace-mcp-api-keys
+    creationPolicy: Owner
+  data:
+    - secretKey: BRAVE_SEARCH_MCP_API_KEY
+      remoteRef:
+        key: traefik-mcp-api-keys
+        property: BRAVE_SEARCH_MCP_API_KEY
+    - secretKey: GITHUB_MCP_API_KEY
+      remoteRef:
+        key: traefik-mcp-api-keys
+        property: GITHUB_MCP_API_KEY
+    - secretKey: KUBECTL_MCP_API_KEY
+      remoteRef:
+        key: traefik-mcp-api-keys
+        property: KUBECTL_MCP_API_KEY
+    - secretKey: VM_MCP_API_KEY
+      remoteRef:
+        key: traefik-mcp-api-keys
+        property: VM_MCP_API_KEY

--- a/cluster/apps/coder-workspaces/coder-workspaces/app/mcp-auth-secret-store.yaml
+++ b/cluster/apps/coder-workspaces/coder-workspaces/app/mcp-auth-secret-store.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-api-keys-reader
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/external-secrets.io/secretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: traefik-mcp-api-keys-store
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: traefik
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: mcp-api-keys-reader

--- a/cluster/apps/coder-workspaces/coder-workspaces/ks.yaml
+++ b/cluster/apps/coder-workspaces/coder-workspaces/ks.yaml
@@ -12,6 +12,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: external-secrets
     - name: kyverno-policies
   prune: true
   timeout: 5m

--- a/cluster/apps/traefik/traefik/app/kustomization.yaml
+++ b/cluster/apps/traefik/traefik/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./fallback-certificate.yaml
   - ./mcp-api-keys-secrets.sops.yaml
+  - ./mcp-auth-reader-rbac.yaml
   - ./release.yaml
   - ./vpa.yaml
   - ./coder-service-reader-rbac.yaml

--- a/cluster/apps/traefik/traefik/app/mcp-auth-reader-rbac.yaml
+++ b/cluster/apps/traefik/traefik/app/mcp-auth-reader-rbac.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/role-rbac-v1.json
+# Allows consumer namespace SAs to read traefik-mcp-api-keys for ESO sync.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: mcp-api-keys-reader
+  namespace: traefik
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["traefik-mcp-api-keys"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["selfsubjectrulesreviews"]
+    verbs: ["create"]
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/rolebinding-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: mcp-api-keys-reader-coder-workspaces
+  namespace: traefik
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: mcp-api-keys-reader
+subjects:
+  - kind: ServiceAccount
+    name: mcp-api-keys-reader
+    namespace: coder-workspaces


### PR DESCRIPTION
## Summary
- Dedup MCP API keys between `traefik` and `coder-workspaces`.
- Pull-model ESO: `coder-workspaces` mounts `coder-workspace-mcp-api-keys` synced from `traefik/traefik-mcp-api-keys` via new SecretStore.
- Least-privilege Role in `traefik` ns (resourceName-scoped) granted to reader SA in `coder-workspaces`.
- Phase 1 = dual-source safe (both env_from blocks active). Phase 2 will strip duplicates from `coder-workspace-env.sops.yaml` after live verification.

## Linked Issue
Ref #985

## Changes
- New: `coder-workspaces/app/mcp-auth-secret-store.yaml` (SA + SecretStore)
- New: `coder-workspaces/app/mcp-auth-external.yaml` (ExternalSecret, 4 keys)
- New: `traefik/app/mcp-auth-reader-rbac.yaml` (Role + RoleBinding)
- Update: both coder workspace template `main.tf` — second `env_from.secret_ref`
- Update: `coder-workspaces/ks.yaml` — `dependsOn: external-secrets`
- Update: `.trivyignore.yaml` — KSV-0113 scoped ignore

## Testing
- [ ] qa-validator APPROVED
- [ ] cluster-validator after merge
- [ ] Verify `ExternalSecret` Ready=True
- [ ] Verify `Secret/coder-workspace-mcp-api-keys` has 4 keys
- [ ] Launch workspace, confirm MCP keys present in env