### PR TITLE
feat(traefik): enable OpenTelemetry tracing export to VictoriaTraces

### DIFF
--- a/cluster/apps/observability/victoria-traces-single/app/network-policies.yaml
+++ b/cluster/apps/observability/victoria-traces-single/app/network-policies.yaml
@@ -29,6 +29,26 @@ spec:
               protocol: TCP
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow ingress from Traefik for OTLP trace ingest on port 10428
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-traefik-traces-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: vt-single
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: traefik
+            k8s:app.kubernetes.io/name: traefik
+      toPorts:
+        - ports:
+            - port: "10428"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
 # Allow Grafana to query traces via Jaeger API on port 10428
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy

--- a/cluster/apps/traefik/traefik/app/kustomization.yaml
+++ b/cluster/apps/traefik/traefik/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./fallback-certificate.yaml
   - ./mcp-api-keys-secrets.sops.yaml
   - ./mcp-api-keys-reader-rbac.yaml
+  - ./network-policies.yaml
   - ./release.yaml
   - ./vpa.yaml
   - ./coder-service-reader-rbac.yaml

--- a/cluster/apps/traefik/traefik/app/network-policies.yaml
+++ b/cluster/apps/traefik/traefik/app/network-policies.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to VictoriaTraces for OTLP trace export on port 10428
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-vtraces-otlp-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: traefik
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+            k8s:app.kubernetes.io/name: vt-single
+      toPorts:
+        - ports:
+            - port: "10428"
+              protocol: TCP

--- a/cluster/apps/traefik/traefik/app/values.yaml
+++ b/cluster/apps/traefik/traefik/app/values.yaml
@@ -16,6 +16,12 @@ resources:
     memory: 256Mi
   limits:
     memory: 1Gi
+tracing:
+  otlp:
+    enabled: true
+    http:
+      enabled: true
+      endpoint: http://victoria-traces-single-vt-single-server.observability.svc:10428/insert/opentelemetry/v1/traces
 ports:
   web:
     http:


### PR DESCRIPTION
## Summary
Enable native OTLP tracing in Traefik to export request spans to VictoriaTraces, providing end-to-end visibility into ingress latency and upstream service performance.

## Linked Issue
Closes #1051

## Changes
- Add `tracing.otlp` config in Traefik helm values pointing to VictoriaTraces HTTP endpoint (`/insert/opentelemetry/v1/traces`)
- Add CiliumNetworkPolicy for Traefik egress to VictoriaTraces on port 10428
- Add CiliumNetworkPolicy for VictoriaTraces ingress from Traefik on port 10428
- Register network-policies.yaml in Traefik kustomization

## Testing
- [ ] Traefik pods restart cleanly after deploy
- [ ] Make HTTP requests through ingress routes
- [ ] Query VictoriaTraces in Grafana for Traefik service traces
- [ ] Verify no CNP drops between traefik and observability namespaces
- [ ] Monitor Traefik CPU/memory via VPA recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)