### PR TITLE
feat(agent-worker): SRE batch observability — config, suppression, batching

### DIFF
--- a/cluster/apps/agent-worker-system/agent-queue-worker/app/values.yaml
+++ b/cluster/apps/agent-worker-system/agent-queue-worker/app/values.yaml
@@ -28,6 +28,10 @@ controllers:
           VALKEY_PORT: "6379"
           N8N_DISPATCH_WEBHOOK: http://n8n-webhook.n8n-system.svc/webhook/agent-dispatch
           GITHUB_OWNER: anthony-spruyt
+          SRE_BATCH_MAX_SIZE: "50"
+          SRE_BATCH_WINDOW_MS: "60000"
+          SRE_COOLDOWN_MS: "300000"
+          SRE_TRIAGE_SUPPRESS_S: "3600"
         envFrom:
           - secretRef:
               name: agent-queue-worker-secrets

--- a/ts/agent-queue-worker/biome.json
+++ b/ts/agent-queue-worker/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "error",
+        "noUnusedVariables": "warn"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useNodejsImportProtocol": "error"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": false
+  },
+  "files": {
+    "includes": ["src/**/*.ts"]
+  }
+}

--- a/ts/agent-queue-worker/package-lock.json
+++ b/ts/agent-queue-worker/package-lock.json
@@ -14,6 +14,7 @@
         "zod": "^4.0.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.13",
         "@types/node": "^24.0.0",
         "tsx": "^4.19.4",
         "typescript": "^6.0.0",
@@ -21,6 +22,181 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@emnapi/core": {

--- a/ts/agent-queue-worker/package.json
+++ b/ts/agent-queue-worker/package.json
@@ -11,6 +11,8 @@
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc --noEmit",
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -25,6 +27,7 @@
     "picomatch": "^4.0.4"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.13",
     "@types/node": "^24.0.0",
     "tsx": "^4.19.4",
     "typescript": "^6.0.0",

--- a/ts/agent-queue-worker/src/config.test.ts
+++ b/ts/agent-queue-worker/src/config.test.ts
@@ -17,6 +17,10 @@ describe("loadConfig", () => {
     delete process.env.VALKEY_PORT;
     delete process.env.PORT;
     delete process.env.GITHUB_TOKEN;
+    delete process.env.SRE_BATCH_MAX_SIZE;
+    delete process.env.SRE_BATCH_WINDOW_MS;
+    delete process.env.SRE_COOLDOWN_MS;
+    delete process.env.SRE_TRIAGE_SUPPRESS_S;
   });
 
   it("parses valid env with defaults", () => {
@@ -75,5 +79,58 @@ describe("loadConfig", () => {
     Object.assign(process.env, VALID_ENV, { GITHUB_TOKEN: "test" });
     const cfg = loadConfig();
     expect(cfg.GITHUB_TOKEN).toBe("test");
+  });
+
+  it("defaults SRE_BATCH_MAX_SIZE to 50", () => {
+    Object.assign(process.env, VALID_ENV);
+    const cfg = loadConfig();
+    expect(cfg.SRE_BATCH_MAX_SIZE).toBe(50);
+  });
+
+  it("coerces SRE_BATCH_MAX_SIZE string to number", () => {
+    Object.assign(process.env, VALID_ENV, { SRE_BATCH_MAX_SIZE: "25" });
+    const cfg = loadConfig();
+    expect(cfg.SRE_BATCH_MAX_SIZE).toBe(25);
+  });
+
+  it("throws when SRE_BATCH_MAX_SIZE is 0", () => {
+    Object.assign(process.env, VALID_ENV, { SRE_BATCH_MAX_SIZE: "0" });
+    expect(() => loadConfig()).toThrow();
+  });
+
+  it("defaults SRE_BATCH_WINDOW_MS to 60000", () => {
+    Object.assign(process.env, VALID_ENV);
+    const cfg = loadConfig();
+    expect(cfg.SRE_BATCH_WINDOW_MS).toBe(60_000);
+  });
+
+  it("allows SRE_BATCH_WINDOW_MS of 0 to disable delay", () => {
+    Object.assign(process.env, VALID_ENV, { SRE_BATCH_WINDOW_MS: "0" });
+    const cfg = loadConfig();
+    expect(cfg.SRE_BATCH_WINDOW_MS).toBe(0);
+  });
+
+  it("defaults SRE_COOLDOWN_MS to 300000", () => {
+    Object.assign(process.env, VALID_ENV);
+    const cfg = loadConfig();
+    expect(cfg.SRE_COOLDOWN_MS).toBe(300_000);
+  });
+
+  it("allows SRE_COOLDOWN_MS of 0 to disable cooldown", () => {
+    Object.assign(process.env, VALID_ENV, { SRE_COOLDOWN_MS: "0" });
+    const cfg = loadConfig();
+    expect(cfg.SRE_COOLDOWN_MS).toBe(0);
+  });
+
+  it("defaults SRE_TRIAGE_SUPPRESS_S to 3600", () => {
+    Object.assign(process.env, VALID_ENV);
+    const cfg = loadConfig();
+    expect(cfg.SRE_TRIAGE_SUPPRESS_S).toBe(3600);
+  });
+
+  it("allows SRE_TRIAGE_SUPPRESS_S of 0 to disable suppression", () => {
+    Object.assign(process.env, VALID_ENV, { SRE_TRIAGE_SUPPRESS_S: "0" });
+    const cfg = loadConfig();
+    expect(cfg.SRE_TRIAGE_SUPPRESS_S).toBe(0);
   });
 });

--- a/ts/agent-queue-worker/src/config.test.ts
+++ b/ts/agent-queue-worker/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { loadConfig } from "./config.js";
 
 const VALID_ENV = {

--- a/ts/agent-queue-worker/src/config.ts
+++ b/ts/agent-queue-worker/src/config.ts
@@ -18,6 +18,10 @@ const ConfigSchema = z.object({
   GITHUB_TOKEN: z.string().optional(),
   GITHUB_OWNER: z.string().min(1),
   PORT: z.coerce.number().int().default(3000),
+  SRE_BATCH_MAX_SIZE: z.coerce.number().int().min(1).default(50),
+  SRE_BATCH_WINDOW_MS: z.coerce.number().int().min(0).default(60_000),
+  SRE_COOLDOWN_MS: z.coerce.number().int().min(0).default(300_000),
+  SRE_TRIAGE_SUPPRESS_S: z.coerce.number().int().min(0).default(3600),
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/ts/agent-queue-worker/src/http/middleware.ts
+++ b/ts/agent-queue-worker/src/http/middleware.ts
@@ -1,4 +1,4 @@
-import { type IncomingMessage, type ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 export function json(res: ServerResponse, status: number, data: unknown): void {
   res.writeHead(status, { "Content-Type": "application/json" });

--- a/ts/agent-queue-worker/src/http/routes.test.ts
+++ b/ts/agent-queue-worker/src/http/routes.test.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { describe, expect, it, vi } from "vitest";
-import { type ServerResponse } from "node:http";
-import { handleGetJob, type RouteDeps } from "./routes.js";
+import type { Config } from "../config.js";
+import { handleAddJob, handleGetJob, type RouteDeps } from "./routes.js";
 
 function mockRes(): ServerResponse & { _status: number; _body: unknown } {
   const res = {
@@ -15,6 +17,15 @@ function mockRes(): ServerResponse & { _status: number; _body: unknown } {
     },
   } as unknown as ServerResponse & { _status: number; _body: unknown };
   return res;
+}
+
+function mockReq(body: unknown): IncomingMessage {
+  const emitter = new EventEmitter();
+  process.nextTick(() => {
+    emitter.emit("data", Buffer.from(JSON.stringify(body)));
+    emitter.emit("end");
+  });
+  return emitter as unknown as IncomingMessage;
 }
 
 const jobData = {
@@ -98,5 +109,99 @@ describe("handleGetJob", () => {
     expect(getJob).toHaveBeenCalledWith("nonexistent");
     expect(res._status).toBe(404);
     expect((res._body as Record<string, unknown>).error).toBe("not_found");
+  });
+});
+
+describe("handleAddJob suppression", () => {
+  const sreAlert = {
+    role: "sre" as const,
+    repo: "org/repo",
+    event_type: "alert",
+    priority: 5,
+    payload: { trigger: "alert", fingerprint: "fp-abc123" },
+  };
+
+  function makeDeps(overrides: Record<string, unknown> = {}): RouteDeps {
+    return {
+      queue: { getJob: vi.fn().mockResolvedValue(null), add: vi.fn() },
+      redis: { exists: vi.fn().mockResolvedValue(0) },
+      circuitBreaker: { check: vi.fn().mockResolvedValue({ open: false }) },
+      rateLimiter: {
+        check: vi.fn().mockResolvedValue({ limited: false }),
+        record: vi.fn(),
+      },
+      registry: {
+        get: vi.fn().mockReturnValue({
+          timeoutMs: 900_000,
+          cooldownMs: 300_000,
+          jobOptions: { attempts: 1 },
+          buildIdentitySegments: () => ["org/repo", "sre-triage"],
+          getJobDelay: () => 0,
+        }),
+      },
+      config: {
+        SRE_BATCH_MAX_SIZE: 50,
+        SRE_BATCH_WINDOW_MS: 60_000,
+        SRE_COOLDOWN_MS: 300_000,
+        SRE_TRIAGE_SUPPRESS_S: 3600,
+      } as Config,
+      processor: {},
+      ...overrides,
+    } as unknown as RouteDeps;
+  }
+
+  it("suppresses triaged SRE alert with 200", async () => {
+    const res = mockRes();
+    const req = mockReq(sreAlert);
+    const deps = makeDeps({
+      redis: { exists: vi.fn().mockResolvedValue(1) },
+    });
+
+    await handleAddJob(req, res, deps);
+
+    expect(res._status).toBe(200);
+    expect((res._body as Record<string, unknown>).reason).toBe(
+      "already_triaged"
+    );
+  });
+
+  it("does not suppress non-triaged SRE alert", async () => {
+    const res = mockRes();
+    const req = mockReq(sreAlert);
+    const deps = makeDeps();
+
+    await handleAddJob(req, res, deps);
+
+    expect(res._status).toBe(201);
+    expect((res._body as Record<string, unknown>).added).toBe(true);
+  });
+
+  it("does not suppress non-SRE role with fingerprint", async () => {
+    const res = mockRes();
+    const req = mockReq({
+      role: "triage",
+      repo: "org/repo",
+      event_type: "pull_request",
+      priority: 5,
+      pr_number: 1,
+      head_sha: "abc",
+      payload: { trigger: "alert", fingerprint: "fp-abc123" },
+    });
+    const deps = makeDeps({
+      redis: { exists: vi.fn().mockResolvedValue(1) },
+      registry: {
+        get: vi.fn().mockReturnValue({
+          timeoutMs: 120_000,
+          jobOptions: {},
+          buildIdentitySegments: () => ["org/repo", "triage-1"],
+          getJobDelay: () => 0,
+        }),
+      },
+    });
+
+    await handleAddJob(req, res, deps);
+
+    expect(res._status).toBe(201);
+    expect((res._body as Record<string, unknown>).added).toBe(true);
   });
 });

--- a/ts/agent-queue-worker/src/http/routes.ts
+++ b/ts/agent-queue-worker/src/http/routes.ts
@@ -1,24 +1,24 @@
-import { type IncomingMessage, type ServerResponse } from "node:http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import type { Queue } from "bullmq";
 import type { Redis } from "ioredis";
+import type { Config } from "../config.js";
+import { buildJobIdentity } from "../job/identity.js";
+import type { AgentJob } from "../job/schema.js";
 import {
   AgentJobInputSchema,
   DoneRequestSchema,
   FailRequestSchema,
 } from "../job/schema.js";
-import type { AgentJob } from "../job/schema.js";
-import { buildJobIdentity } from "../job/identity.js";
-import type { RoleRegistry } from "../roles/registry.js";
-import { resolveDuplicateAction } from "../roles/types.js";
-import type { JobState } from "../roles/types.js";
-import type { Processor } from "../processor.js";
-import type { CircuitBreaker, RateLimiter } from "../queue/guard.js";
-import type { Config } from "../config.js";
-import { sreTriagedKey } from "../roles/sre-role.js";
-import { json, parseAndValidate } from "./middleware.js";
-import { DEFAULT_JOB_OPTIONS } from "../queue/options.js";
 import { logger } from "../logger.js";
 import * as metrics from "../metrics.js";
+import type { Processor } from "../processor.js";
+import type { CircuitBreaker, RateLimiter } from "../queue/guard.js";
+import { DEFAULT_JOB_OPTIONS } from "../queue/options.js";
+import type { RoleRegistry } from "../roles/registry.js";
+import { sreTriagedKey } from "../roles/sre-role.js";
+import type { JobState } from "../roles/types.js";
+import { resolveDuplicateAction } from "../roles/types.js";
+import { json, parseAndValidate } from "./middleware.js";
 
 // Atomic state-checked update: only HSET if job is still in wait/prioritized/paused.
 // The non-atomic getJob+getState before this call is acceptable because this Lua
@@ -66,7 +66,11 @@ export async function handleAddJob(
     return json(res, 429, { added: false, reason: "circuit_open" });
   }
 
-  if (data.payload?.trigger === "alert" && data.payload?.fingerprint) {
+  if (
+    data.role === "sre" &&
+    data.payload?.trigger === "alert" &&
+    data.payload?.fingerprint
+  ) {
     const fpKey = sreTriagedKey(data.repo, String(data.payload.fingerprint));
     const triaged = await deps.redis.exists(fpKey);
     if (triaged) {

--- a/ts/agent-queue-worker/src/http/routes.ts
+++ b/ts/agent-queue-worker/src/http/routes.ts
@@ -13,6 +13,8 @@ import { resolveDuplicateAction } from "../roles/types.js";
 import type { JobState } from "../roles/types.js";
 import type { Processor } from "../processor.js";
 import type { CircuitBreaker, RateLimiter } from "../queue/guard.js";
+import type { Config } from "../config.js";
+import { sreTriagedKey } from "../roles/sre-role.js";
 import { json, parseAndValidate } from "./middleware.js";
 import { DEFAULT_JOB_OPTIONS } from "../queue/options.js";
 import { logger } from "../logger.js";
@@ -20,8 +22,12 @@ import * as metrics from "../metrics.js";
 
 // Atomic state-checked update: only HSET if job is still in wait/prioritized/paused.
 // The non-atomic getJob+getState before this call is acceptable because this Lua
-// re-validates state atomically — the outer check is an optimization to avoid
+// re-validates state atomically -- the outer check is an optimization to avoid
 // unnecessary EVAL calls, not a correctness dependency.
+// NOTE: Does not check the BullMQ delayed sorted set. This is safe because no
+// onDuplicate implementation returns "replace" for delayed jobs (SRE alerts always
+// return "buffer"; all other roles discard non-waiting/prioritized states). If a
+// future role needs to replace delayed jobs, extend this script to check the delayed set.
 // Uses Redis EVAL command (server-side Lua execution), not JavaScript eval().
 const ATOMIC_UPDATE_IF_WAITING_LUA = `
 local inWait   = redis.call('LPOS', KEYS[1], ARGV[2])
@@ -41,6 +47,7 @@ export interface RouteDeps {
   registry: RoleRegistry;
   circuitBreaker: CircuitBreaker;
   rateLimiter: RateLimiter;
+  config: Config;
 }
 
 export async function handleAddJob(
@@ -59,6 +66,15 @@ export async function handleAddJob(
     return json(res, 429, { added: false, reason: "circuit_open" });
   }
 
+  if (data.payload?.trigger === "alert" && data.payload?.fingerprint) {
+    const fpKey = sreTriagedKey(data.repo, String(data.payload.fingerprint));
+    const triaged = await deps.redis.exists(fpKey);
+    if (triaged) {
+      metrics.sreSuppressed.inc({ role: data.role });
+      return json(res, 200, { added: false, reason: "already_triaged" });
+    }
+  }
+
   const identity = buildJobIdentity(data, deps.registry);
   const jobId = identity.jobId;
   const roleDef = deps.registry.get(data.role);
@@ -73,7 +89,7 @@ export async function handleAddJob(
       if (shouldBuffer) {
         const bufKey = roleDef.bufferKey!(jobId);
         await deps.redis.rpush(bufKey, JSON.stringify(data.payload));
-        await deps.redis.ltrim(bufKey, -50, -1);
+        await deps.redis.ltrim(bufKey, -deps.config.SRE_BATCH_MAX_SIZE, -1);
         await deps.redis.expire(bufKey, 3600);
 
         try {
@@ -129,7 +145,7 @@ export async function handleAddJob(
       if (decision.action === "buffer") {
         const bufKey = roleDef.bufferKey!(jobId);
         await deps.redis.rpush(bufKey, JSON.stringify(data.payload));
-        await deps.redis.ltrim(bufKey, -50, -1);
+        await deps.redis.ltrim(bufKey, -deps.config.SRE_BATCH_MAX_SIZE, -1);
         await deps.redis.expire(bufKey, 3600);
         metrics.dedupActionCounter.inc({
           queue: "agent",
@@ -165,11 +181,13 @@ export async function handleAddJob(
   }
 
   try {
+    const delay = roleDef.getJobDelay?.(data) ?? 0;
     await deps.queue.add(data.role, data, {
       ...DEFAULT_JOB_OPTIONS,
       ...roleDef.jobOptions,
       jobId,
       priority: data.priority,
+      ...(delay > 0 && { delay }),
     });
 
     await deps.rateLimiter.record(data.repo, jobId);

--- a/ts/agent-queue-worker/src/http/server.ts
+++ b/ts/agent-queue-worker/src/http/server.ts
@@ -1,5 +1,4 @@
 import { createServer, type Server } from "node:http";
-import type { Config } from "../config.js";
 import { json, authenticate } from "./middleware.js";
 import {
   handleAddJob,
@@ -14,7 +13,6 @@ import { logger } from "../logger.js";
 import * as metrics from "../metrics.js";
 
 export interface ServerDeps extends RouteDeps {
-  config: Config;
   isReady: () => boolean;
 }
 

--- a/ts/agent-queue-worker/src/http/server.ts
+++ b/ts/agent-queue-worker/src/http/server.ts
@@ -1,16 +1,16 @@
 import { createServer, type Server } from "node:http";
-import { json, authenticate } from "./middleware.js";
-import {
-  handleAddJob,
-  handleGetJob,
-  handleCompleteJob,
-  handleFailJob,
-  handleRetryJob,
-  handleResetCircuit,
-} from "./routes.js";
-import type { RouteDeps } from "./routes.js";
 import { logger } from "../logger.js";
 import * as metrics from "../metrics.js";
+import { authenticate, json } from "./middleware.js";
+import type { RouteDeps } from "./routes.js";
+import {
+  handleAddJob,
+  handleCompleteJob,
+  handleFailJob,
+  handleGetJob,
+  handleResetCircuit,
+  handleRetryJob,
+} from "./routes.js";
 
 export interface ServerDeps extends RouteDeps {
   isReady: () => boolean;

--- a/ts/agent-queue-worker/src/index.ts
+++ b/ts/agent-queue-worker/src/index.ts
@@ -1,12 +1,12 @@
-import { Worker, Queue } from "bullmq";
+import { Queue, Worker } from "bullmq";
 import { Redis } from "ioredis";
 import { loadConfig } from "./config.js";
-import { Processor } from "./processor.js";
 import { createHttpServer } from "./http/server.js";
+import * as metrics from "./metrics.js";
+import { Processor } from "./processor.js";
 import { CircuitBreaker, RateLimiter } from "./queue/guard.js";
 import { setupLifecycle } from "./queue/lifecycle.js";
 import { createDefaultRegistry } from "./roles/registry.js";
-import * as metrics from "./metrics.js";
 
 const config = loadConfig();
 

--- a/ts/agent-queue-worker/src/index.ts
+++ b/ts/agent-queue-worker/src/index.ts
@@ -6,6 +6,7 @@ import { createHttpServer } from "./http/server.js";
 import { CircuitBreaker, RateLimiter } from "./queue/guard.js";
 import { setupLifecycle } from "./queue/lifecycle.js";
 import { createDefaultRegistry } from "./roles/registry.js";
+import * as metrics from "./metrics.js";
 
 const config = loadConfig();
 
@@ -26,7 +27,7 @@ const connection = {
 const queueOpts = { connection, prefix: "agent:queue" };
 
 const queue = new Queue("agent", queueOpts);
-const registry = createDefaultRegistry();
+const registry = createDefaultRegistry(config, metrics.sreBatchSize);
 const processor = new Processor(redis, config, registry);
 const circuitBreaker = new CircuitBreaker(redis);
 const rateLimiter = new RateLimiter(redis);

--- a/ts/agent-queue-worker/src/job/identity.test.ts
+++ b/ts/agent-queue-worker/src/job/identity.test.ts
@@ -1,9 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildJobIdentity, extractRole } from "./identity.js";
 import { createDefaultRegistry } from "../roles/registry.js";
 import type { AgentJob } from "./schema.js";
+import type { Histogram } from "prom-client";
+import type { Config } from "../config.js";
 
-const registry = createDefaultRegistry();
+const mockConfig = {
+  SRE_BATCH_MAX_SIZE: 50,
+  SRE_BATCH_WINDOW_MS: 60_000,
+  SRE_COOLDOWN_MS: 300_000,
+  SRE_TRIAGE_SUPPRESS_S: 3600,
+} as Config;
+
+const mockHistogram = { observe: vi.fn() } as unknown as Histogram;
+
+const registry = createDefaultRegistry(mockConfig, mockHistogram);
 
 const base: AgentJob = {
   role: "triage",

--- a/ts/agent-queue-worker/src/job/identity.test.ts
+++ b/ts/agent-queue-worker/src/job/identity.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
-import { buildJobIdentity, extractRole } from "./identity.js";
-import { createDefaultRegistry } from "../roles/registry.js";
-import type { AgentJob } from "./schema.js";
 import type { Histogram } from "prom-client";
+import { describe, expect, it, vi } from "vitest";
 import type { Config } from "../config.js";
+import { createDefaultRegistry } from "../roles/registry.js";
+import { buildJobIdentity, extractRole } from "./identity.js";
+import type { AgentJob } from "./schema.js";
 
 const mockConfig = {
   SRE_BATCH_MAX_SIZE: 50,

--- a/ts/agent-queue-worker/src/job/identity.ts
+++ b/ts/agent-queue-worker/src/job/identity.ts
@@ -1,5 +1,5 @@
-import type { AgentJob } from "./schema.js";
 import type { RoleRegistry } from "../roles/registry.js";
+import type { AgentJob } from "./schema.js";
 
 export interface JobIdentity {
   jobId: string;

--- a/ts/agent-queue-worker/src/job/schema.test.ts
+++ b/ts/agent-queue-worker/src/job/schema.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
+import type { AgentJob } from "./schema.js";
 import {
-  AgentJobSchema,
   AgentJobInputSchema,
+  AgentJobSchema,
   DoneRequestSchema,
   FailRequestSchema,
 } from "./schema.js";
-import type { AgentJob } from "./schema.js";
 
 const base: AgentJob = {
   role: "triage",

--- a/ts/agent-queue-worker/src/logger.ts
+++ b/ts/agent-queue-worker/src/logger.ts
@@ -16,7 +16,7 @@ function log(level: Level, msg: string, fields?: LogFields): void {
   if (LEVELS[level] < minLevel) return;
   const entry = { ts: new Date().toISOString(), level, msg, ...fields };
   const out = level === "error" ? process.stderr : process.stdout;
-  out.write(JSON.stringify(entry) + "\n");
+  out.write(`${JSON.stringify(entry)}\n`);
 }
 
 export const logger = {

--- a/ts/agent-queue-worker/src/metrics.ts
+++ b/ts/agent-queue-worker/src/metrics.ts
@@ -58,3 +58,17 @@ export const dedupActionCounter = new Counter({
   labelNames: ["queue", "role", "action"] as const,
   registers: [registry],
 });
+
+export const sreBatchSize = new Histogram({
+  name: "agent_sre_batch_size",
+  help: "Total alerts per SRE batch (trigger + buffered)",
+  buckets: [1, 5, 10, 20, 50],
+  registers: [registry],
+});
+
+export const sreSuppressed = new Counter({
+  name: "agent_sre_suppressed_total",
+  help: "Alerts suppressed by fingerprint dedup",
+  labelNames: ["role"] as const,
+  registers: [registry],
+});

--- a/ts/agent-queue-worker/src/metrics.ts
+++ b/ts/agent-queue-worker/src/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Histogram, Gauge, Registry } from "prom-client";
+import { Counter, Gauge, Histogram, Registry } from "prom-client";
 
 export const registry = new Registry();
 registry.setDefaultLabels({ service: "agent-queue-worker" });

--- a/ts/agent-queue-worker/src/processor.ts
+++ b/ts/agent-queue-worker/src/processor.ts
@@ -1,11 +1,11 @@
-import { Job } from "bullmq";
 import { randomUUID } from "node:crypto";
+import type { Job } from "bullmq";
 import type { Redis } from "ioredis";
+import type { Config } from "./config.js";
 import type { AgentJob, JobResult } from "./job/schema.js";
-import type { RoleRegistry } from "./roles/registry.js";
 import { logger } from "./logger.js";
 import * as metrics from "./metrics.js";
-import type { Config } from "./config.js";
+import type { RoleRegistry } from "./roles/registry.js";
 
 // Lua script for atomic session token validation (check -> delete -> accept).
 // Eliminates TOCTOU gap. Token consumed on first valid use — replay-proof.

--- a/ts/agent-queue-worker/src/queue/lifecycle.test.ts
+++ b/ts/agent-queue-worker/src/queue/lifecycle.test.ts
@@ -1,0 +1,290 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "../config.js";
+import { type LifecycleDeps, setupLifecycle } from "./lifecycle.js";
+
+vi.mock("../github.js", () => ({
+  fetchReposWithRevertLabels: vi.fn().mockResolvedValue(new Map()),
+}));
+
+vi.mock("../logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("../metrics.js", () => ({
+  queueDepth: { set: vi.fn() },
+  jobFailures: { inc: vi.fn() },
+  jobExhausted: { inc: vi.fn() },
+  workerShutdowns: { inc: vi.fn() },
+  dedupActionCounter: { inc: vi.fn() },
+}));
+
+const mockConfig = {
+  PORT: 3000,
+  GITHUB_OWNER: "org",
+  GITHUB_TOKEN: "tok",
+  SRE_BATCH_MAX_SIZE: 50,
+  SRE_BATCH_WINDOW_MS: 60_000,
+  SRE_COOLDOWN_MS: 300_000,
+  SRE_TRIAGE_SUPPRESS_S: 3600,
+} as Config;
+
+function createMockDeps() {
+  const worker = new EventEmitter();
+  const pipelineExec = vi.fn().mockResolvedValue([]);
+  const pipeline = vi.fn().mockReturnValue({
+    set: vi.fn().mockReturnThis(),
+    exec: pipelineExec,
+  });
+  const redis = {
+    pipeline,
+    get: vi.fn(),
+    set: vi.fn(),
+    rpush: vi.fn(),
+    ltrim: vi.fn(),
+    expire: vi.fn(),
+    quit: vi.fn(),
+  };
+  const queue = {
+    add: vi.fn(),
+    close: vi.fn(),
+    getWaitingCount: vi.fn().mockResolvedValue(0),
+    getJobCountByTypes: vi.fn().mockResolvedValue(0),
+  };
+  const server = {
+    listen: vi.fn((_port: number, cb: () => void) => cb()),
+    close: vi.fn((cb: () => void) => cb()),
+  };
+  const drainBuffer = vi.fn().mockResolvedValue({
+    role: "sre",
+    repo: "org/repo",
+    event_type: "alert",
+    priority: 5,
+    payload: { trigger: "alert" },
+  });
+  const registry = {
+    get: vi.fn().mockReturnValue({
+      timeoutMs: 900_000,
+      cooldownMs: 300_000,
+      jobOptions: { attempts: 1 },
+      bufferKey: (id: string) => `agent:sre-alerts:${id}`,
+      drainBuffer,
+    }),
+  };
+
+  return {
+    worker,
+    queue,
+    redis,
+    server,
+    registry,
+    drainBuffer,
+    pipeline,
+    pipelineExec,
+    deps: {
+      worker,
+      queue,
+      redis,
+      processor: { cancelAll: vi.fn() },
+      registry,
+      circuitBreaker: { trip: vi.fn() },
+      server,
+      config: mockConfig,
+    } as unknown as LifecycleDeps,
+  };
+}
+
+describe("lifecycle triaged marker writes", () => {
+  let mocks: ReturnType<typeof createMockDeps>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks = createMockDeps();
+    setupLifecycle(mocks.deps);
+  });
+
+  it("writes triaged marker for job fingerprint", async () => {
+    const job = {
+      id: "org/repo--sre-triage",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "alert",
+        priority: 5,
+        payload: { trigger: "alert", fingerprint: "fp-1" },
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await vi.waitFor(() => {
+      expect(mocks.pipeline).toHaveBeenCalled();
+    });
+
+    const pipe = mocks.pipeline.mock.results[0]?.value;
+    expect(pipe.set).toHaveBeenCalledWith(
+      "agent:sre-triaged:org/repo:fp-1",
+      "1",
+      "EX",
+      3600
+    );
+    expect(mocks.pipelineExec).toHaveBeenCalled();
+  });
+
+  it("writes markers for fingerprints in alerts array", async () => {
+    const job = {
+      id: "org/repo--sre-triage",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "alert",
+        priority: 5,
+        payload: {
+          trigger: "alert",
+          fingerprint: "fp-main",
+          alerts: [{ fingerprint: "fp-a1" }, { fingerprint: "fp-a2" }],
+        },
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await vi.waitFor(() => {
+      expect(mocks.pipeline).toHaveBeenCalled();
+    });
+
+    const pipe = mocks.pipeline.mock.results[0]?.value;
+    expect(pipe.set).toHaveBeenCalledTimes(3);
+    expect(pipe.set).toHaveBeenCalledWith(
+      "agent:sre-triaged:org/repo:fp-main",
+      "1",
+      "EX",
+      3600
+    );
+    expect(pipe.set).toHaveBeenCalledWith(
+      "agent:sre-triaged:org/repo:fp-a1",
+      "1",
+      "EX",
+      3600
+    );
+    expect(pipe.set).toHaveBeenCalledWith(
+      "agent:sre-triaged:org/repo:fp-a2",
+      "1",
+      "EX",
+      3600
+    );
+  });
+
+  it("uses per-job triage_suppress_s override", async () => {
+    const job = {
+      id: "org/repo--sre-triage",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "alert",
+        priority: 5,
+        payload: {
+          trigger: "alert",
+          fingerprint: "fp-1",
+          triage_suppress_s: 7200,
+        },
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await vi.waitFor(() => {
+      expect(mocks.pipeline).toHaveBeenCalled();
+    });
+
+    const pipe = mocks.pipeline.mock.results[0]?.value;
+    expect(pipe.set).toHaveBeenCalledWith(
+      "agent:sre-triaged:org/repo:fp-1",
+      "1",
+      "EX",
+      7200
+    );
+  });
+
+  it("skips marker writes for non-alert jobs", async () => {
+    const job = {
+      id: "org/repo--sre-health-check-d1",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "schedule",
+        priority: 5,
+        payload: { trigger: "schedule" },
+        dedup_key: "d1",
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(mocks.pipeline).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates fingerprints across job and alerts", async () => {
+    const job = {
+      id: "org/repo--sre-triage",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "alert",
+        priority: 5,
+        payload: {
+          trigger: "alert",
+          fingerprint: "fp-dup",
+          alerts: [{ fingerprint: "fp-dup" }, { fingerprint: "fp-unique" }],
+        },
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await vi.waitFor(() => {
+      expect(mocks.pipeline).toHaveBeenCalled();
+    });
+
+    const pipe = mocks.pipeline.mock.results[0]?.value;
+    expect(pipe.set).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows pipeline errors with warning", async () => {
+    mocks.pipelineExec.mockRejectedValueOnce(new Error("Redis down"));
+    const { logger } = await import("../logger.js");
+
+    const job = {
+      id: "org/repo--sre-triage",
+      data: {
+        role: "sre",
+        repo: "org/repo",
+        event_type: "alert",
+        priority: 5,
+        payload: { trigger: "alert", fingerprint: "fp-1" },
+      },
+      opts: {},
+      attemptsMade: 0,
+    };
+
+    await mocks.worker.emit("completed", job);
+    await vi.waitFor(() => {
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Failed to write triaged markers",
+        expect.objectContaining({ jobId: "org/repo--sre-triage" })
+      );
+    });
+  });
+});

--- a/ts/agent-queue-worker/src/queue/lifecycle.ts
+++ b/ts/agent-queue-worker/src/queue/lifecycle.ts
@@ -1,15 +1,15 @@
 import type { Server } from "node:http";
-import type { Worker, Queue } from "bullmq";
+import type { Queue, Worker } from "bullmq";
 import type { Redis } from "ioredis";
-import type { Processor } from "../processor.js";
-import type { RoleRegistry } from "../roles/registry.js";
-import type { CircuitBreaker } from "./guard.js";
 import type { Config } from "../config.js";
 import { fetchReposWithRevertLabels } from "../github.js";
-import { DEFAULT_JOB_OPTIONS } from "./options.js";
 import { logger } from "../logger.js";
 import * as metrics from "../metrics.js";
+import type { Processor } from "../processor.js";
+import type { RoleRegistry } from "../roles/registry.js";
 import { sreTriagedKey } from "../roles/sre-role.js";
+import type { CircuitBreaker } from "./guard.js";
+import { DEFAULT_JOB_OPTIONS } from "./options.js";
 
 export interface LifecycleDeps {
   worker: Worker;

--- a/ts/agent-queue-worker/src/queue/lifecycle.ts
+++ b/ts/agent-queue-worker/src/queue/lifecycle.ts
@@ -9,6 +9,7 @@ import { fetchReposWithRevertLabels } from "../github.js";
 import { DEFAULT_JOB_OPTIONS } from "./options.js";
 import { logger } from "../logger.js";
 import * as metrics from "../metrics.js";
+import { sreTriagedKey } from "../roles/sre-role.js";
 
 export interface LifecycleDeps {
   worker: Worker;
@@ -39,11 +40,53 @@ export function setupLifecycle(deps: LifecycleDeps): void {
     const roleDef = registry.get(job.data.role);
     if (!roleDef.bufferKey || !roleDef.drainBuffer) return;
 
+    if (job.data.payload?.trigger === "alert") {
+      const suppressTtl = Number(
+        job.data.payload?.triage_suppress_s ?? config.SRE_TRIAGE_SUPPRESS_S
+      );
+      const fingerprints = new Set<string>();
+
+      if (job.data.payload?.fingerprint) {
+        fingerprints.add(String(job.data.payload.fingerprint));
+      }
+      const processedAlerts = job.data.payload?.alerts as
+        | Array<Record<string, unknown>>
+        | undefined;
+      if (processedAlerts) {
+        for (const a of processedAlerts) {
+          if (a.fingerprint) fingerprints.add(String(a.fingerprint));
+        }
+      }
+
+      if (fingerprints.size > 0 && suppressTtl > 0) {
+        try {
+          const pipeline = redis.pipeline();
+          for (const fp of fingerprints) {
+            pipeline.set(
+              sreTriagedKey(job.data.repo, fp),
+              "1",
+              "EX",
+              suppressTtl
+            );
+          }
+          await pipeline.exec();
+          logger.debug("Wrote triaged markers", {
+            jobId: job.id,
+            count: fingerprints.size,
+            ttlSeconds: suppressTtl,
+          });
+        } catch (err) {
+          logger.warn("Failed to write triaged markers", {
+            jobId: job.id,
+            error: String(err),
+          });
+        }
+      }
+    }
+
     try {
       const drainedData = await roleDef.drainBuffer(job.id!, job.data, redis);
-      const alerts = drainedData.payload?.buffered_alerts as
-        | unknown[]
-        | undefined;
+      const alerts = drainedData.payload?.alerts as unknown[] | undefined;
       if (!alerts || alerts.length === 0) return;
 
       try {
@@ -70,7 +113,7 @@ export function setupLifecycle(deps: LifecycleDeps): void {
       } catch {
         const bufKey = roleDef.bufferKey!(job.id!);
         await redis.rpush(bufKey, ...alerts.map((a) => JSON.stringify(a)));
-        await redis.ltrim(bufKey, -50, -1);
+        await redis.ltrim(bufKey, -config.SRE_BATCH_MAX_SIZE, -1);
         await redis.expire(bufKey, 3600);
         logger.warn("Re-pushed alerts after failed auto-queue", {
           jobId: job.id,

--- a/ts/agent-queue-worker/src/roles/execute-role.ts
+++ b/ts/agent-queue-worker/src/roles/execute-role.ts
@@ -1,5 +1,5 @@
-import type { RoleDefinition, DuplicateAction, JobState } from "./types.js";
 import type { AgentJob } from "../job/schema.js";
+import type { DuplicateAction, JobState, RoleDefinition } from "./types.js";
 
 export const executeRole: RoleDefinition = {
   timeoutMs: 3_600_000,

--- a/ts/agent-queue-worker/src/roles/pr-role.ts
+++ b/ts/agent-queue-worker/src/roles/pr-role.ts
@@ -1,7 +1,7 @@
-import type { RoleDefinition, StalenessResult } from "./types.js";
-import type { AgentJob } from "../job/schema.js";
-import { getCurrentPrHead } from "../github.js";
 import type { Config } from "../config.js";
+import { getCurrentPrHead } from "../github.js";
+import type { AgentJob } from "../job/schema.js";
+import type { RoleDefinition, StalenessResult } from "./types.js";
 
 export function createPrRole(
   roleName: string,

--- a/ts/agent-queue-worker/src/roles/registry.ts
+++ b/ts/agent-queue-worker/src/roles/registry.ts
@@ -1,8 +1,10 @@
+import type { Histogram } from "prom-client";
 import type { RoleDefinition } from "./types.js";
+import type { Config } from "../config.js";
 import { createPrRole } from "./pr-role.js";
 import { validateRole } from "./validate-role.js";
 import { executeRole } from "./execute-role.js";
-import { sreRole } from "./sre-role.js";
+import { createSreRole } from "./sre-role.js";
 
 export class RoleRegistry {
   private roles = new Map<string, RoleDefinition>();
@@ -26,12 +28,15 @@ export class RoleRegistry {
   }
 }
 
-export function createDefaultRegistry(): RoleRegistry {
+export function createDefaultRegistry(
+  config: Config,
+  batchSizeHistogram: Histogram
+): RoleRegistry {
   const registry = new RoleRegistry();
   registry.register("triage", createPrRole("triage", 600_000));
   registry.register("fix", createPrRole("fix", 1_800_000));
   registry.register("validate", validateRole);
   registry.register("execute", executeRole);
-  registry.register("sre", sreRole);
+  registry.register("sre", createSreRole(config, batchSizeHistogram));
   return registry;
 }

--- a/ts/agent-queue-worker/src/roles/registry.ts
+++ b/ts/agent-queue-worker/src/roles/registry.ts
@@ -1,10 +1,10 @@
 import type { Histogram } from "prom-client";
-import type { RoleDefinition } from "./types.js";
 import type { Config } from "../config.js";
-import { createPrRole } from "./pr-role.js";
-import { validateRole } from "./validate-role.js";
 import { executeRole } from "./execute-role.js";
+import { createPrRole } from "./pr-role.js";
 import { createSreRole } from "./sre-role.js";
+import type { RoleDefinition } from "./types.js";
+import { validateRole } from "./validate-role.js";
 
 export class RoleRegistry {
   private roles = new Map<string, RoleDefinition>();

--- a/ts/agent-queue-worker/src/roles/roles.test.ts
+++ b/ts/agent-queue-worker/src/roles/roles.test.ts
@@ -273,3 +273,68 @@ describe("sre cooldownMs from config", () => {
     expect(def.cooldownMs).toBe(120_000);
   });
 });
+
+describe("sre drainBuffer", () => {
+  const def = registry.get("sre");
+  const job: AgentJob = {
+    ...base,
+    role: "sre" as const,
+    payload: { trigger: "alert", alertname: "HighCPU" },
+  };
+
+  beforeEach(() => {
+    vi.mocked(mockHistogram.observe).mockClear();
+  });
+
+  it("observes histogram with drained count", async () => {
+    const items = [
+      JSON.stringify({ alertname: "A1" }),
+      JSON.stringify({ alertname: "A2" }),
+      JSON.stringify({ alertname: "A3" }),
+      JSON.stringify({ alertname: "A4" }),
+      JSON.stringify({ alertname: "A5" }),
+    ];
+    const mockRedis = {
+      eval: vi.fn().mockResolvedValue(items),
+    } as any;
+
+    const result = await def.drainBuffer!("job1", job, mockRedis);
+
+    expect(mockHistogram.observe).toHaveBeenCalledWith(6);
+    expect(result.payload?.alerts).toHaveLength(5);
+  });
+
+  it("uses alerts field not buffered_alerts", async () => {
+    const items = [JSON.stringify({ alertname: "A1" })];
+    const mockRedis = {
+      eval: vi.fn().mockResolvedValue(items),
+    } as any;
+
+    const result = await def.drainBuffer!("job1", job, mockRedis);
+
+    expect(result.payload?.alerts).toBeDefined();
+    expect(result.payload?.buffered_alerts).toBeUndefined();
+  });
+
+  it("does not observe histogram when buffer is empty", async () => {
+    const mockRedis = {
+      eval: vi.fn().mockResolvedValue([]),
+    } as any;
+
+    const result = await def.drainBuffer!("job1", job, mockRedis);
+
+    expect(mockHistogram.observe).not.toHaveBeenCalled();
+    expect(result).toBe(job);
+  });
+
+  it("does not observe histogram when buffer is null", async () => {
+    const mockRedis = {
+      eval: vi.fn().mockResolvedValue(null),
+    } as any;
+
+    const result = await def.drainBuffer!("job1", job, mockRedis);
+
+    expect(mockHistogram.observe).not.toHaveBeenCalled();
+    expect(result).toBe(job);
+  });
+});

--- a/ts/agent-queue-worker/src/roles/roles.test.ts
+++ b/ts/agent-queue-worker/src/roles/roles.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDefaultRegistry } from "./registry.js";
 import { resolveDuplicateAction } from "./types.js";
 import type { AgentJob } from "../job/schema.js";
 import type { JobState } from "./types.js";
+import { Histogram } from "prom-client";
+import type { Config } from "../config.js";
 
-const registry = createDefaultRegistry();
+const mockConfig = {
+  SRE_BATCH_MAX_SIZE: 50,
+  SRE_BATCH_WINDOW_MS: 60_000,
+  SRE_COOLDOWN_MS: 300_000,
+  SRE_TRIAGE_SUPPRESS_S: 3600,
+} as Config;
+
+const mockHistogram = { observe: vi.fn() } as unknown as Histogram;
+
+const registry = createDefaultRegistry(mockConfig, mockHistogram);
 
 const base: AgentJob = {
   role: "triage",
@@ -197,5 +208,68 @@ describe("registry", () => {
       "triage",
       "validate",
     ]);
+  });
+});
+
+describe("sre getJobDelay", () => {
+  const def = registry.get("sre");
+
+  it("returns batch window for alert trigger", () => {
+    const job = {
+      ...base,
+      role: "sre" as const,
+      payload: { trigger: "alert" },
+    };
+    expect(def.getJobDelay!(job)).toBe(60_000);
+  });
+
+  it("returns per-job override when present", () => {
+    const job = {
+      ...base,
+      role: "sre" as const,
+      payload: { trigger: "alert", batch_window_ms: 30_000 },
+    };
+    expect(def.getJobDelay!(job)).toBe(30_000);
+  });
+
+  it("caps per-job override at 6 hours", () => {
+    const job = {
+      ...base,
+      role: "sre" as const,
+      payload: { trigger: "alert", batch_window_ms: 999_999_999 },
+    };
+    expect(def.getJobDelay!(job)).toBe(21_600_000);
+  });
+
+  it("returns 0 for scheduled jobs", () => {
+    const job = { ...base, role: "sre" as const, dedup_key: "d1" };
+    expect(def.getJobDelay!(job)).toBe(0);
+  });
+
+  it("returns 0 when batch window is 0", () => {
+    const zeroConfig = { ...mockConfig, SRE_BATCH_WINDOW_MS: 0 } as Config;
+    const zeroHistogram = { observe: vi.fn() } as unknown as Histogram;
+    const zeroRegistry = createDefaultRegistry(zeroConfig, zeroHistogram);
+    const def2 = zeroRegistry.get("sre");
+    const job = {
+      ...base,
+      role: "sre" as const,
+      payload: { trigger: "alert" },
+    };
+    expect(def2.getJobDelay!(job)).toBe(0);
+  });
+});
+
+describe("sre cooldownMs from config", () => {
+  it("reads cooldownMs from SRE_COOLDOWN_MS config", () => {
+    const def = registry.get("sre");
+    expect(def.cooldownMs).toBe(300_000);
+  });
+
+  it("respects custom cooldown value", () => {
+    const customConfig = { ...mockConfig, SRE_COOLDOWN_MS: 120_000 } as Config;
+    const customRegistry = createDefaultRegistry(customConfig, mockHistogram);
+    const def = customRegistry.get("sre");
+    expect(def.cooldownMs).toBe(120_000);
   });
 });

--- a/ts/agent-queue-worker/src/roles/roles.test.ts
+++ b/ts/agent-queue-worker/src/roles/roles.test.ts
@@ -1,10 +1,10 @@
+import type { Histogram } from "prom-client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createDefaultRegistry } from "./registry.js";
-import { resolveDuplicateAction } from "./types.js";
-import type { AgentJob } from "../job/schema.js";
-import type { JobState } from "./types.js";
-import { Histogram } from "prom-client";
 import type { Config } from "../config.js";
+import type { AgentJob } from "../job/schema.js";
+import { createDefaultRegistry } from "./registry.js";
+import type { JobState } from "./types.js";
+import { resolveDuplicateAction } from "./types.js";
 
 const mockConfig = {
   SRE_BATCH_MAX_SIZE: 50,
@@ -239,6 +239,15 @@ describe("sre getJobDelay", () => {
       payload: { trigger: "alert", batch_window_ms: 999_999_999 },
     };
     expect(def.getJobDelay!(job)).toBe(21_600_000);
+  });
+
+  it("clamps negative per-job override to 0", () => {
+    const job = {
+      ...base,
+      role: "sre" as const,
+      payload: { trigger: "alert", batch_window_ms: -1 },
+    };
+    expect(def.getJobDelay!(job)).toBe(0);
   });
 
   it("returns 0 for scheduled jobs", () => {

--- a/ts/agent-queue-worker/src/roles/sre-role.ts
+++ b/ts/agent-queue-worker/src/roles/sre-role.ts
@@ -1,8 +1,8 @@
 import type { Redis } from "ioredis";
 import type { Histogram } from "prom-client";
-import type { RoleDefinition, DuplicateAction, JobState } from "./types.js";
-import type { AgentJob } from "../job/schema.js";
 import type { Config } from "../config.js";
+import type { AgentJob } from "../job/schema.js";
+import type { DuplicateAction, JobState, RoleDefinition } from "./types.js";
 
 // Atomic drain: LRANGE all items then DEL key in one round-trip.
 // Uses Redis EVAL command (server-side Lua execution), not JavaScript eval().
@@ -79,7 +79,7 @@ export function createSreRole(
         const raw = Number(
           job.payload?.batch_window_ms ?? config.SRE_BATCH_WINDOW_MS
         );
-        return Math.min(raw, 21_600_000);
+        return Math.max(0, Math.min(raw, 21_600_000));
       }
       return 0;
     },

--- a/ts/agent-queue-worker/src/roles/sre-role.ts
+++ b/ts/agent-queue-worker/src/roles/sre-role.ts
@@ -1,6 +1,8 @@
 import type { Redis } from "ioredis";
+import type { Histogram } from "prom-client";
 import type { RoleDefinition, DuplicateAction, JobState } from "./types.js";
 import type { AgentJob } from "../job/schema.js";
+import type { Config } from "../config.js";
 
 // Atomic drain: LRANGE all items then DEL key in one round-trip.
 // Uses Redis EVAL command (server-side Lua execution), not JavaScript eval().
@@ -11,57 +13,77 @@ return items
 `;
 
 const SRE_BUFFER_PREFIX = "agent:sre-alerts:";
+const SRE_TRIAGED_PREFIX = "agent:sre-triaged:";
 
 function sreBufferKey(jobId: string): string {
   return `${SRE_BUFFER_PREFIX}${jobId}`;
 }
 
-export const sreRole: RoleDefinition = {
-  timeoutMs: 900_000,
-  cooldownMs: 300_000,
-  jobOptions: { attempts: 1 },
-  buildIdentitySegments(job: AgentJob): string[] {
-    if (job.payload?.trigger === "alert") {
-      return [job.repo, "sre-triage"];
-    }
-    if (!job.dedup_key)
-      throw new Error("dedup_key required for sre scheduled jobs");
-    return [job.repo, "sre-health-check", job.dedup_key];
-  },
-  onDuplicate(
-    _existing: AgentJob,
-    incoming: AgentJob,
-    state: JobState
-  ): DuplicateAction {
-    if (incoming.payload?.trigger === "alert") {
-      return { action: "buffer" };
-    }
-    return state === "waiting" || state === "prioritized"
-      ? { action: "replace" }
-      : { action: "discard" };
-  },
-  bufferKey: sreBufferKey,
-  async drainBuffer(
-    jobId: string,
-    data: AgentJob,
-    redis: Redis
-  ): Promise<AgentJob> {
-    // Redis EVAL runs Lua server-side for atomic drain
-    const items = (await redis.eval(
-      DRAIN_BUFFER_LUA,
-      1,
-      sreBufferKey(jobId)
-    )) as string[];
-    if (!items || items.length === 0) return data;
-    const alerts = items.map((i) => JSON.parse(i) as Record<string, unknown>);
-    return {
-      ...data,
-      payload: {
-        ...data.payload,
-        buffered_alerts: alerts,
-      },
-    };
-  },
-};
+export function sreTriagedKey(repo: string, fingerprint: string): string {
+  return `${SRE_TRIAGED_PREFIX}${repo}:${fingerprint}`;
+}
 
-export { DRAIN_BUFFER_LUA };
+export function createSreRole(
+  config: Config,
+  batchSizeHistogram: Histogram
+): RoleDefinition {
+  return {
+    timeoutMs: 900_000,
+    cooldownMs: config.SRE_COOLDOWN_MS,
+    jobOptions: { attempts: 1 },
+    buildIdentitySegments(job: AgentJob): string[] {
+      if (job.payload?.trigger === "alert") {
+        return [job.repo, "sre-triage"];
+      }
+      if (!job.dedup_key)
+        throw new Error("dedup_key required for sre scheduled jobs");
+      return [job.repo, "sre-health-check", job.dedup_key];
+    },
+    onDuplicate(
+      _existing: AgentJob,
+      incoming: AgentJob,
+      state: JobState
+    ): DuplicateAction {
+      if (incoming.payload?.trigger === "alert") {
+        return { action: "buffer" };
+      }
+      return state === "waiting" || state === "prioritized"
+        ? { action: "replace" }
+        : { action: "discard" };
+    },
+    bufferKey: sreBufferKey,
+    async drainBuffer(
+      jobId: string,
+      data: AgentJob,
+      redis: Redis
+    ): Promise<AgentJob> {
+      // Redis EVAL runs Lua server-side for atomic drain
+      const items = (await redis.eval(
+        DRAIN_BUFFER_LUA,
+        1,
+        sreBufferKey(jobId)
+      )) as string[];
+      if (!items || items.length === 0) return data;
+      batchSizeHistogram.observe(items.length + 1);
+      const alerts = items.map((i) => JSON.parse(i) as Record<string, unknown>);
+      return {
+        ...data,
+        payload: {
+          ...data.payload,
+          alerts,
+        },
+      };
+    },
+    getJobDelay(job: AgentJob): number {
+      if (job.payload?.trigger === "alert") {
+        const raw = Number(
+          job.payload?.batch_window_ms ?? config.SRE_BATCH_WINDOW_MS
+        );
+        return Math.min(raw, 21_600_000);
+      }
+      return 0;
+    },
+  };
+}
+
+export { DRAIN_BUFFER_LUA, SRE_TRIAGED_PREFIX };

--- a/ts/agent-queue-worker/src/roles/types.ts
+++ b/ts/agent-queue-worker/src/roles/types.ts
@@ -27,6 +27,7 @@ export interface RoleDefinition {
   ): DuplicateAction;
   bufferKey?(jobId: string): string;
   drainBuffer?(jobId: string, data: AgentJob, redis: Redis): Promise<AgentJob>;
+  getJobDelay?(job: AgentJob): number;
 }
 
 export function resolveDuplicateAction(

--- a/ts/agent-queue-worker/src/roles/types.ts
+++ b/ts/agent-queue-worker/src/roles/types.ts
@@ -1,7 +1,7 @@
-import type { Redis } from "ioredis";
 import type { JobsOptions } from "bullmq";
-import type { AgentJob } from "../job/schema.js";
+import type { Redis } from "ioredis";
 import type { Config } from "../config.js";
+import type { AgentJob } from "../job/schema.js";
 
 export type DuplicateAction =
   | { action: "replace" }

--- a/ts/agent-queue-worker/src/roles/validate-role.ts
+++ b/ts/agent-queue-worker/src/roles/validate-role.ts
@@ -1,5 +1,5 @@
-import type { RoleDefinition } from "./types.js";
 import type { AgentJob } from "../job/schema.js";
+import type { RoleDefinition } from "./types.js";
 
 export const validateRole: RoleDefinition = {
   timeoutMs: 1_800_000,


### PR DESCRIPTION
## Summary

- Add configurable SRE batch cap, batch window (delayed jobs), cooldown, and fingerprint suppression TTL
- Convert SRE role to factory pattern closing over config + histogram
- Fingerprint-based alert suppression via Redis TTL keys (write on completion, check on ingress)
- Batch size histogram (`agent_sre_batch_size`) and suppression counter (`agent_sre_suppressed_total`)
- Field rename `buffered_alerts` → `alerts`

## Linked Issue

Closes #1184

## Changes

- **Config** (`config.ts`): 4 new Zod fields — `SRE_BATCH_MAX_SIZE` (50), `SRE_BATCH_WINDOW_MS` (60s), `SRE_COOLDOWN_MS` (5m), `SRE_TRIAGE_SUPPRESS_S` (1h)
- **Metrics** (`metrics.ts`): `sreBatchSize` histogram, `sreSuppressed` counter
- **Types** (`types.ts`): `getJobDelay` optional method on `RoleDefinition`
- **SRE Role** (`sre-role.ts`): `createSreRole(config, histogram)` factory with `getJobDelay`, histogram observation in `drainBuffer`, exported `sreTriagedKey`
- **Registry** (`registry.ts`): `createDefaultRegistry(config, histogram)` signature
- **Routes** (`routes.ts`): Fingerprint suppression check before identity resolution, config LTRIM, batch window delay via `getJobDelay`
- **Lifecycle** (`lifecycle.ts`): Write triaged markers (Redis pipeline SET EX), config LTRIM, field rename
- **Helm** (`values.yaml`): 4 SRE env vars
- **Tests**: 200 total (was 178), covering config defaults/coercion/validation, drainBuffer histogram, getJobDelay with overrides, cooldown from config

## Testing

- `npx vitest run` — 200/200 pass
- `npx tsc --noEmit` — clean
- Verified no hardcoded `-50` remains
- Verified no `buffered_alerts` in production code
- n8n workflow update done separately (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)