### PR TITLE
fix(coder): add SSH key rotation grace period for Kata VM mounts

### DIFF
--- a/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
@@ -305,8 +305,8 @@ resource "coder_agent" "main" {
     export XDG_RUNTIME_DIR=/run/user/1000
 
     # Configure git commit signing using the read-only SSH key mount.
-    # Points directly at the secret volume so key rotation takes effect
-    # without a workspace restart (~1 min propagation delay).
+    # Kata virtiofs mounts are frozen at pod creation — secret updates
+    # do NOT propagate. Grace period on rotation keeps old key valid.
     git config --global gpg.format ssh
     git config --global user.signingKey /etc/coder/ssh-keys/id_ed25519
     git config --global commit.gpgSign true
@@ -319,7 +319,8 @@ resource "coder_agent" "main" {
     GIT_COMMITTER_NAME  = local.git_author_name
     GIT_COMMITTER_EMAIL = local.git_author_email
     # SSH auth uses the read-only key mount directly — no copy needed.
-    # Key rotation propagates automatically via Kubernetes secret volume refresh.
+    # Kata virtiofs: mount frozen at pod creation; rotation grace period
+    # keeps old key valid on GitHub until next rotation cycle.
     GIT_SSH_COMMAND = "ssh -i /etc/coder/ssh-keys/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
   }
 

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/spruyt-labs/main.tf
@@ -342,8 +342,8 @@ resource "coder_agent" "main" {
     sudo chown vscode:vscode /home/vscode/.terraform.d/credentials.tfrc.json
 
     # Configure git commit signing using the read-only SSH key mount.
-    # Points directly at the secret volume so key rotation takes effect
-    # without a workspace restart (~1 min propagation delay).
+    # Kata virtiofs mounts are frozen at pod creation — secret updates
+    # do NOT propagate. Grace period on rotation keeps old key valid.
     git config --global gpg.format ssh
     git config --global user.signingKey /etc/coder/ssh-keys/id_ed25519
     git config --global commit.gpgSign true
@@ -356,7 +356,8 @@ resource "coder_agent" "main" {
     GIT_COMMITTER_NAME  = local.git_author_name
     GIT_COMMITTER_EMAIL = local.git_author_email
     # SSH auth uses the read-only key mount directly — no copy needed.
-    # Key rotation propagates automatically via Kubernetes secret volume refresh.
+    # Kata virtiofs: mount frozen at pod creation; rotation grace period
+    # keeps old key valid on GitHub until next rotation cycle.
     GIT_SSH_COMMAND   = "ssh -i /etc/coder/ssh-keys/id_ed25519 -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
     TALOSCONFIG       = "/etc/coder/talos/config"
     SOPS_AGE_KEY_FILE = "/etc/coder/sops/age.key"

--- a/cluster/apps/coder-workspaces/ssh-key-rotation/README.md
+++ b/cluster/apps/coder-workspaces/ssh-key-rotation/README.md
@@ -23,6 +23,10 @@ Weekly CronJob that rotates the `coder-ssh-signing-key` Secret used by Coder wor
    - **Symptom**: Job logs `connection refused` to kube-apiserver or GitHub.
    - **Resolution**: Egress CNPs live in `app/network-policy.yaml` (`allow-ssh-rotation-*`). Confirm the pod label `app: ssh-key-rotation` still matches.
 
+## Kata VM grace period
+
+Kata virtiofs mounts are frozen at pod creation — Kubernetes secret volume updates do NOT propagate into the guest. `GRACE_PERIOD_DAYS=8` keeps the previous key valid on GitHub for one full rotation cycle (7 days) plus buffer, so workspaces that span a rotation boundary continue signing/pushing.
+
 ## References
 
 - [Coder SSH keys](https://coder.com/docs/admin/external-auth)

--- a/cluster/apps/coder-workspaces/ssh-key-rotation/app/cronjob.yaml
+++ b/cluster/apps/coder-workspaces/ssh-key-rotation/app/cronjob.yaml
@@ -43,6 +43,8 @@ spec:
                   value: coder-ssh-signing-key
                 - name: SECRET_NAMESPACE
                   value: coder-workspaces
+                - name: GRACE_PERIOD_DAYS
+                  value: "8"
               resources:
                 requests:
                   cpu: 10m

--- a/cluster/apps/coder-workspaces/ssh-key-rotation/app/cronjob.yaml
+++ b/cluster/apps/coder-workspaces/ssh-key-rotation/app/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: rotate-ssh-key
-              image: ghcr.io/anthony-spruyt/ssh-key-rotation:2.0.2@sha256:1419826607abcae88c687955649abb7744f1b2fa886cc9ddb0f7e34b6778e9e0
+              image: ghcr.io/anthony-spruyt/ssh-key-rotation:2.0.3@sha256:c1e6db9cfa023d88d8f8bc00348b3fa8ea54e31e58edfd8828648621d2636187
               env:
                 - name: GITHUB_PAT
                   valueFrom:

--- a/cluster/apps/github-system/bot-ssh-key-rotation/app/cronjob.yaml
+++ b/cluster/apps/github-system/bot-ssh-key-rotation/app/cronjob.yaml
@@ -43,6 +43,8 @@ spec:
                   value: github-bot-ssh-key
                 - name: SECRET_NAMESPACE
                   value: github-system
+                - name: GRACE_PERIOD_DAYS
+                  value: "4"
                 - name: FORCE_SYNC_NAMESPACES
                   value: claude-agents-write
                 - name: FORCE_SYNC_ES_NAME

--- a/cluster/apps/github-system/bot-ssh-key-rotation/app/cronjob.yaml
+++ b/cluster/apps/github-system/bot-ssh-key-rotation/app/cronjob.yaml
@@ -30,7 +30,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: rotate-ssh-key
-              image: ghcr.io/anthony-spruyt/ssh-key-rotation:2.0.2@sha256:1419826607abcae88c687955649abb7744f1b2fa886cc9ddb0f7e34b6778e9e0
+              image: ghcr.io/anthony-spruyt/ssh-key-rotation:2.0.3@sha256:c1e6db9cfa023d88d8f8bc00348b3fa8ea54e31e58edfd8828648621d2636187
               env:
                 - name: GITHUB_PAT
                   valueFrom:


### PR DESCRIPTION
## Summary
- Add `GRACE_PERIOD_DAYS` env var to both SSH key rotation CronJobs
- Fix misleading template comments claiming secret volumes auto-update in Kata VMs
- Document Kata virtiofs limitation in README

## Linked Issue
Closes #1281

## Changes
- `ssh-key-rotation` CronJob: `GRACE_PERIOD_DAYS=8` (full weekly cycle + 1d buffer)
- `bot-ssh-key-rotation` CronJob: `GRACE_PERIOD_DAYS=4` (half cycle, prevents race with active bots)
- Both workspace templates: replace incorrect "~1 min propagation delay" comments with Kata virtiofs freeze explanation
- README: add Kata VM grace period section

## Dependencies
Requires [container-images#564](https://github.com/anthony-spruyt/container-images/pull/564) merged + new image version. Until then, env var is a no-op (ignored by current image v2.0.2).

## Testing
- YAML linting + kustomize dry-run pass
- Comment changes are documentation-only
- End-to-end verification after image rebuild: rotation job should log "Grace period: N days" and preserve keys within the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)