### PR TITLE
chore(renovate): add repo-specific overrides for package rules

### DIFF
--- a/.github/renovate-overrides.json5
+++ b/.github/renovate-overrides.json5
@@ -1,0 +1,25 @@
+// Repo-specific Renovate overrides — not synced after creation
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Disable kubernetes manager for runner sidecar (version managed via kustomize images transformer)",
+      matchManagers: ["kubernetes"],
+      matchPackageNames: ["n8nio/runners"],
+      pinDigests: false,
+      enabled: false
+    },
+    {
+      description: "Coder uses two-channel releases (mainline/stable); 30-day delay avoids adopting unproven mainline versions",
+      matchPackageNames: ["coder"],
+      matchDatasources: ["helm"],
+      minimumReleaseAge: "30 days"
+    },
+    {
+      description: "Disable dockerfile manager for golang (ARG interpolation breaks updates; custom.regex manager handles these via annotations)",
+      matchManagers: ["dockerfile"],
+      matchPackageNames: ["golang"],
+      enabled: false
+    }
+  ]
+}

--- a/.taskfiles/dev-env/scripts/renovate-dry-run.sh
+++ b/.taskfiles/dev-env/scripts/renovate-dry-run.sh
@@ -39,17 +39,18 @@ if ! python3 -c "import json5" 2>/dev/null; then
 fi
 
 # Fetch remote github> presets and merge everything into one config
-python3 - "$MAIN_CONFIG" "$RENOVATE_DIR" "$MERGED_CONFIG" "$PRESET_TMPDIR" "$TOKEN" <<'PYEOF'
+python3 - "$MAIN_CONFIG" "$RENOVATE_DIR" "$MERGED_CONFIG" "$PRESET_TMPDIR" "$TOKEN" "$REPO_ROOT" <<'PYEOF'
 import json, json5, glob, sys, os, urllib.request, base64
 
-main_config, local_preset_dir, output, tmpdir, token = sys.argv[1:6]
+main_config, local_preset_dir, output, tmpdir, token, repo_root = sys.argv[1:7]
 
 with open(main_config) as f:
     config = json5.loads(f.read())
 
-# Separate github> presets from built-in presets
+# Separate github> and local> presets from built-in presets
 github_presets = [e for e in config.get('extends', []) if e.startswith('github>')]
-config['extends'] = [e for e in config.get('extends', []) if not e.startswith('github>')]
+local_presets = [e for e in config.get('extends', []) if e.startswith('local>')]
+config['extends'] = [e for e in config.get('extends', []) if not e.startswith(('github>', 'local>'))]
 
 def fetch_github_preset(preset_ref, token):
     """Fetch a github>owner/repo//.path preset file via GitHub API."""
@@ -97,7 +98,7 @@ for preset_ref in github_presets:
         merge_preset(config, preset)
         fetched += 1
 
-# Merge local preset overrides (if any exist)
+# Merge local preset overrides from .github/renovate/ dir (if any exist)
 local_count = 0
 if os.path.isdir(local_preset_dir):
     for path in sorted(glob.glob(os.path.join(local_preset_dir, '**', '*.json5'), recursive=True)):
@@ -105,6 +106,19 @@ if os.path.isdir(local_preset_dir):
             preset = json5.loads(f.read())
         merge_preset(config, preset)
         local_count += 1
+
+# Resolve local> extends (e.g., local>.github/renovate-overrides)
+for local_ref in local_presets:
+    rel_path = local_ref.removeprefix('local>')
+    for ext in ['.json5', '.json', '']:
+        candidate = os.path.join(repo_root, rel_path + ext)
+        if os.path.isfile(candidate):
+            print(f"  Merging local preset {candidate}...", file=sys.stderr)
+            with open(candidate) as f:
+                preset = json5.loads(f.read())
+            merge_preset(config, preset)
+            local_count += 1
+            break
 
 with open(output, 'w') as f:
     json.dump(config, f, indent=2)


### PR DESCRIPTION
## Summary
- Create `.github/renovate-overrides.json5` with repo-specific Renovate rules moved from shared repo-operator config
- Update dry-run script to resolve `local>` extends

## Linked Issue
Closes #1317

## Changes
- **n8nio/runners** kubernetes manager disable + pinDigests off (fixes flapping PRs #1154, #1209, #1303)
- **coder** 30-day release age delay
- **golang** dockerfile manager disable (ARG interpolation workaround)
- Dry-run script now resolves `local>` preset references alongside `github>` ones

## Testing
- Pre-commit hooks pass
- Part of cross-repo change: repo-operator PR anthony-spruyt/repo-operator#143, container-images PR anthony-spruyt/container-images#578

🤖 Generated with [Claude Code](https://claude.com/claude-code)