### PR TITLE
fix(devcontainer): use GitHub-hosted taskfile install script

### DIFF
--- a/.devcontainer/setup-devcontainer.sh
+++ b/.devcontainer/setup-devcontainer.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Called by post-create.sh after safe-chain, pre-commit, and claude-cli are installed.
 
 # Install taskfile runner
-curl -sSfL https://taskfile.dev/install.sh | sudo sh -s -- -b /usr/local/bin
+curl -sSfL https://raw.githubusercontent.com/go-task/task/main/install-task.sh | sudo sh -s -- -b /usr/local/bin
 
 echo "Installing repo-specific tools via taskfile..."
 


### PR DESCRIPTION
## Summary
- Switch taskfile install URL from `taskfile.dev/install.sh` to `raw.githubusercontent.com/go-task/task/main/install-task.sh`
- Same install script, more reliable host — avoids devcontainer setup failures when taskfile.dev CDN is down

## Linked Issue
Closes #1352

## Changes
- `.devcontainer/setup-devcontainer.sh`: Replace taskfile.dev URL with GitHub raw URL

## Testing
- Ran install script manually — installs Task v3.50.0 successfully