### PR TITLE
feat(security): enable readOnlyRootFilesystem for headlamp

### DIFF
--- a/cluster/apps/headlamp-system/headlamp/app/values.yaml
+++ b/cluster/apps/headlamp-system/headlamp/app/values.yaml
@@ -39,6 +39,18 @@ pluginsManager:
       parallel: true
       maxConcurrent: 2
 
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
 resources:
   requests:
     cpu: 35m


### PR DESCRIPTION
## Summary
- Enable `readOnlyRootFilesystem: true` on headlamp container
- Add full container security hardening: drop ALL capabilities, seccomp RuntimeDefault, no privilege escalation
- Plugin manager inherits same security context automatically via chart logic

## Linked Issue
Closes #1370

## Changes
- Added `securityContext` block to headlamp Helm values with `readOnlyRootFilesystem`, `runAsNonRoot`, `runAsUser/Group`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`, `seccompProfile: RuntimeDefault`

## Testing
- Chart v0.42.0 auto-creates `/tmp` emptyDir volumes when `readOnlyRootFilesystem: true` — verified in upstream template logic
- UID 100 / GID 101 match upstream chart defaults
- QA validator passed (schema, lint, dry-run, security)