### PR TITLE
feat(litellm): deploy LiteLLM Proxy as centralized LLM gateway

### DIFF
--- a/cluster/apps/authentik-system/authentik/app/authentik-litellm-oauth.sops.yaml
+++ b/cluster/apps/authentik-system/authentik/app/authentik-litellm-oauth.sops.yaml
@@ -1,0 +1,27 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: authentik-litellm-oauth
+    namespace: authentik-system
+    annotations:
+        kustomize.toolkit.fluxcd.io/ssa: IfNotPresent
+type: Opaque
+stringData:
+    LITELLM_OAUTH_CLIENT_ID: ENC[AES256_GCM,data:MWd4YtgFCzC6HXNIHwj3PuYYYrjyK7KSOfXIygJZagg=,iv:h53lx5Rgk/lk4MPVzeKDzYyaDP4+WVsFpTBbwmzvN4M=,tag:UMUrfyRtHJnUK7np9sAf+w==,type:str]
+    LITELLM_OAUTH_CLIENT_SECRET: ENC[AES256_GCM,data:BeX6RWa7nJ56hq1mvQKDFeaY0Iy+Fs/LXDzpuKWcCLnKMvo5Cc/YsjJF6nmf3Arjym15OpM+haM62GTMbHIR6g==,iv:nXQgm8KeRuTxzuUf7n/0QNKyb32QSX4fot2i8Hyytps=,tag:DEedRgQ3cTWnYjKDfVsUxg==,type:str]
+sops:
+    age:
+        - recipient: age1lt4xakktwyjvsqe6e09ca8f7nsljua3lynd7d9lzcs39fyqt8ggq87glw5
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqUU5hTVFzYVF1RmQwSXIy
+            Q0h0eHhPVk5jTTZ3dGNpNjVieDNZSk9CV1FVCm40d0IzdS92ZTlrTXMxbGc3VHZL
+            cWJyYnc2TUtTOWFsS3BHWm5WcUdTV00KLS0tIGtQRlVSc3JueVlyemwzdk90KytL
+            djdBSlQzekE2UGl5MXNmZkZrYkJ4ckkKVkADWueT4D134tQzTRJnUmtndNJaaFkO
+            RndxbIvCSgOSWdwpKjLbWLcWY+RKecOTVFoqlnxdBmAig3GZ1XLq1g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-15T03:57:18Z"
+    mac: ENC[AES256_GCM,data:OFRhVHIrASItV54e6Y5lwzQWH98nrK0jYf1Mk9b64xFqY848LiOfxtCE3H8UzsUuqolHO49XRK5fWodb/UfXIV8gUDhU85/zwZ7OFW6HtJX9SrIIaG3LrhxrVVeVSc8PQSfp9AaDmtJ3CuDtynIw84CHdJz3K5kptyvgBnsPK5g=,iv:t/PY/buYUpcBn24SoMcXUboVdIFVcCIfSXO74oVDASE=,tag:3NeCjtSkn7lcdwwDbIQWyA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/cluster/apps/authentik-system/authentik/app/blueprints/litellm-sso.yaml
+++ b/cluster/apps/authentik-system/authentik/app/blueprints/litellm-sso.yaml
@@ -1,0 +1,76 @@
+# yamllint disable-file
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goauthentik/authentik/refs/heads/main/blueprints/schema.json
+---
+version: 1
+metadata:
+  name: LiteLLM SSO
+entries:
+  - id: litellm_users_group
+    model: authentik_core.group
+    identifiers:
+      name: LiteLLM Users
+    attrs:
+      name: LiteLLM Users
+
+  - id: litellm_admins_group
+    model: authentik_core.group
+    identifiers:
+      name: LiteLLM Admins
+    attrs:
+      name: LiteLLM Admins
+      parent: !KeyOf litellm_users_group
+
+  - id: litellm_provider
+    model: authentik_providers_oauth2.oauth2provider
+    identifiers:
+      name: LiteLLM
+    attrs:
+      authorization_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-authorization-implicit-consent"],
+        ]
+      invalidation_flow:
+        !Find [
+          authentik_flows.flow,
+          [slug, "default-provider-invalidation-flow"],
+        ]
+      client_type: confidential
+      redirect_uris:
+        - url: https://litellm.${EXTERNAL_DOMAIN}/sso/callback
+          matching_mode: strict
+      client_id: !Env LITELLM_OAUTH_CLIENT_ID
+      client_secret: !Env LITELLM_OAUTH_CLIENT_SECRET
+      property_mappings:
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "authentik default OAuth Mapping: OpenID 'openid'"],
+          ]
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "authentik default OAuth Mapping: OpenID 'profile'"],
+          ]
+        - !Find [
+            authentik_core.propertymapping,
+            [name, "authentik default OAuth Mapping: OpenID 'email'"],
+          ]
+
+  - id: litellm_application
+    model: authentik_core.application
+    identifiers:
+      slug: litellm
+    attrs:
+      name: LiteLLM
+      provider: !KeyOf litellm_provider
+      meta_launch_url: https://litellm.${EXTERNAL_DOMAIN}
+      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/litellm.png
+
+  - model: authentik_policies.policybinding
+    identifiers:
+      target: !KeyOf litellm_application
+      order: 0
+    attrs:
+      group: !KeyOf litellm_users_group
+      negate: false
+      enabled: true
+      timeout: 30

--- a/cluster/apps/authentik-system/authentik/app/external-secrets-rbac.yaml
+++ b/cluster/apps/authentik-system/authentik/app/external-secrets-rbac.yaml
@@ -151,3 +151,34 @@ subjects:
   - kind: ServiceAccount
     name: authentik-secret-reader
     namespace: technitium
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/role-rbac-v1.json
+# Allows litellm namespace to read only LiteLLM OAuth secret (least-privilege)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: litellm-oauth-reader
+  namespace: authentik-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["authentik-litellm-oauth"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["selfsubjectrulesreviews"]
+    verbs: ["create"]
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/rolebinding-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: litellm-oauth-reader
+  namespace: authentik-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: litellm-oauth-reader
+subjects:
+  - kind: ServiceAccount
+    name: authentik-secret-reader
+    namespace: litellm

--- a/cluster/apps/authentik-system/authentik/app/kustomization.yaml
+++ b/cluster/apps/authentik-system/authentik/app/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - ./authentik-coder-oauth.sops.yaml
   # Created once by Flux (ssa: IfNotPresent), then managed by oauth-secret-rotation CronJob
   - ./authentik-technitium-oauth.sops.yaml
+  # Created once by Flux (ssa: IfNotPresent), then managed by oauth-secret-rotation CronJob
+  - ./authentik-litellm-oauth.sops.yaml
   - ./authentik-cnpg-object-stores.yaml
   - ./external-secrets-rbac.yaml
   - ./authentik-cnpg-cluster.yaml
@@ -49,5 +51,6 @@ configMapGenerator:
       - blueprints/bull-board-sso.yaml
       - blueprints/technitium-sso.yaml
       - blueprints/agentmemory-sso.yaml
+      - blueprints/litellm-sso.yaml
 configurations:
   - ./kustomizeconfig.yaml

--- a/cluster/apps/authentik-system/authentik/app/oauth-secret-rotation/cronjob.yaml
+++ b/cluster/apps/authentik-system/authentik/app/oauth-secret-rotation/cronjob.yaml
@@ -92,6 +92,9 @@ spec:
                   # Rotate Coder OAuth
                   rotate_oauth "Coder" "authentik-coder-oauth" "CODER_OIDC_CLIENT_SECRET" "coder-oauth-credentials" "coder-system"
 
+                  # Rotate LiteLLM OAuth
+                  rotate_oauth "LiteLLM" "authentik-litellm-oauth" "LITELLM_OAUTH_CLIENT_SECRET" "litellm-oauth-credentials" "litellm"
+
                   echo "All OAuth secret rotations completed successfully!"
               env:
                 - name: AUTHENTIK_API_TOKEN

--- a/cluster/apps/authentik-system/authentik/app/oauth-secret-rotation/role.yaml
+++ b/cluster/apps/authentik-system/authentik/app/oauth-secret-rotation/role.yaml
@@ -15,5 +15,6 @@ rules:
         "authentik-vaultwarden-oauth",
         "authentik-headlamp-oauth",
         "authentik-coder-oauth",
+        "authentik-litellm-oauth",
       ]
     verbs: ["get", "patch"]

--- a/cluster/apps/authentik-system/authentik/app/values.yaml
+++ b/cluster/apps/authentik-system/authentik/app/values.yaml
@@ -105,6 +105,16 @@ global:
         secretKeyRef:
           name: authentik-technitium-oauth
           key: TECHNITIUM_OIDC_CLIENT_SECRET
+    - name: LITELLM_OAUTH_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: authentik-litellm-oauth
+          key: LITELLM_OAUTH_CLIENT_ID
+    - name: LITELLM_OAUTH_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: authentik-litellm-oauth
+          key: LITELLM_OAUTH_CLIENT_SECRET
     # OAuth rotation service account token (used via !Env tag in blueprint)
     - name: OAUTH_ROTATION_API_TOKEN
       valueFrom:
@@ -191,6 +201,8 @@ global:
             path: technitium-sso.yaml
           - key: agentmemory-sso.yaml
             path: agentmemory-sso.yaml
+          - key: litellm-sso.yaml
+            path: litellm-sso.yaml
 
 authentik:
   log_level: info

--- a/cluster/apps/claude-agents-shared/base/network-policies.yaml
+++ b/cluster/apps/claude-agents-shared/base/network-policies.yaml
@@ -134,3 +134,23 @@ spec:
               protocol: TCP
             - port: "8080"
               protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to LiteLLM proxy for LLM API access
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-litellm-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      managed-by: n8n-claude-code
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: litellm
+            k8s:app.kubernetes.io/name: litellm
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
@@ -98,9 +98,8 @@ locals {
     "OTEL_RESOURCE_ATTRIBUTES" : "agent.namespace=coder-workspaces,workspace.name=${data.coder_workspace.me.name},workspace.owner=${data.coder_workspace_owner.me.name}",
     "AGENTMEMORY_URL" : "http://agentmemory.agentmemory.svc.cluster.local:3111",
     "AGENTMEMORY_SECRET" : "unused-cluster-internal",
-    # LiteLLM proxy — routes Claude Code CLI through Z.ai gateway (#1451)
+    # LiteLLM proxy — routes Claude Code CLI through Alibaba Cloud Model Studio (#1451)
     "ANTHROPIC_BASE_URL"                : "http://litellm.litellm.svc.cluster.local:4000",
-    "ANTHROPIC_MODEL"                   : "glm-5.1",
     "CLAUDE_CODE_ATTRIBUTION_HEADER"    : "0",
     "CLAUDE_CODE_MAX_CONTEXT_TOKENS"    : "200000",
     "ENABLE_TOOL_SEARCH"                : "true",

--- a/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
+++ b/cluster/apps/coder-system/coder-template-sync/app/templates/devcontainer/main.tf
@@ -98,6 +98,12 @@ locals {
     "OTEL_RESOURCE_ATTRIBUTES" : "agent.namespace=coder-workspaces,workspace.name=${data.coder_workspace.me.name},workspace.owner=${data.coder_workspace_owner.me.name}",
     "AGENTMEMORY_URL" : "http://agentmemory.agentmemory.svc.cluster.local:3111",
     "AGENTMEMORY_SECRET" : "unused-cluster-internal",
+    # LiteLLM proxy — routes Claude Code CLI through Z.ai gateway (#1451)
+    "ANTHROPIC_BASE_URL"                : "http://litellm.litellm.svc.cluster.local:4000",
+    "ANTHROPIC_MODEL"                   : "glm-5.1",
+    "CLAUDE_CODE_ATTRIBUTION_HEADER"    : "0",
+    "CLAUDE_CODE_MAX_CONTEXT_TOKENS"    : "200000",
+    "ENABLE_TOOL_SEARCH"                : "true",
   }
 }
 

--- a/cluster/apps/kustomization.yaml
+++ b/cluster/apps/kustomization.yaml
@@ -40,6 +40,7 @@ resources:
   - ./authentik-system
   - ./headlamp-system
   - ./kyverno
+  - ./litellm
   - ./falco-system
   - ./firefly-iii
   - ./nut-system

--- a/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
+++ b/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
@@ -213,8 +213,6 @@ spec:
                       secretKeyRef:
                         name: mcp-credentials
                         key: litellm-api-key
-                  - name: ANTHROPIC_MODEL
-                    value: "glm-5.1"
                   - name: CLAUDE_CODE_ATTRIBUTION_HEADER
                     value: "0"
                   - name: CLAUDE_CODE_MAX_CONTEXT_TOKENS

--- a/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
+++ b/cluster/apps/kyverno/policies/app/inject-claude-agent-config.yaml
@@ -206,6 +206,21 @@ spec:
                     value: http://victoria-traces-single-vt-single-server.observability.svc:10428/insert/opentelemetry/v1/traces
                   - name: OTEL_RESOURCE_ATTRIBUTES
                     value: "agent.namespace={{request.object.metadata.namespace}}"
+                  - name: ANTHROPIC_BASE_URL
+                    value: "http://litellm.litellm.svc.cluster.local:4000"
+                  - name: ANTHROPIC_AUTH_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: mcp-credentials
+                        key: litellm-api-key
+                  - name: ANTHROPIC_MODEL
+                    value: "glm-5.1"
+                  - name: CLAUDE_CODE_ATTRIBUTION_HEADER
+                    value: "0"
+                  - name: CLAUDE_CODE_MAX_CONTEXT_TOKENS
+                    value: "200000"
+                  - name: ENABLE_TOOL_SEARCH
+                    value: "true"
                 volumeMounts:
                   - name: github-gh-config
                     mountPath: /etc/gh-secret

--- a/cluster/apps/litellm/README.md
+++ b/cluster/apps/litellm/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-LiteLLM Proxy provides a centralized, OpenAI-compatible LLM gateway backed by Z.ai (Zhipu AI) GLM models. Replaces direct Anthropic API usage for Claude Code CLI automation, providing flat-rate pricing, virtual key management, spend tracking, and OTEL observability.
+LiteLLM Proxy provides a centralized, OpenAI-compatible LLM gateway backed by Alibaba Cloud Model Studio (DashScope). Routes multiple model providers (Qwen, DeepSeek, Zhipu GLM, MiniMax, Kimi) through a single gateway. Replaces direct Anthropic API usage for Claude Code CLI automation, providing virtual key management, spend tracking, and OTEL observability.
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ Blueprint creates:
 | BerriAI/litellm#25868 | Tool results silently dropped (list-format content)    | Monitor, wait for upstream fix                  |
 | BerriAI/litellm#27839 | Multi-turn conversations may get stuck                 | Retry logic in consumers                        |
 | Claude Code cost_usd  | Broken — internal price table only knows Claude models | Use LiteLLM Grafana dashboard for cost tracking |
-| Cache tokens          | Zero — GLM has no prompt caching                       | Expected behavior                               |
+| Cache tokens          | Zero — models may lack prompt caching                  | Expected behavior                               |
 
 ### Security: PyPI Supply Chain Advisory
 
@@ -72,14 +72,15 @@ LiteLLM PyPI versions 1.82.7-1.82.8 were compromised. **NEVER install from PyPI.
    - **Symptom**: Login redirects endlessly between LiteLLM and Authentik
    - **Resolution**: Verify `PROXY_BASE_URL` matches the IngressRoute hostname exactly. Check Authentik Application redirect URI includes `/sso/callback`.
 
-1. **Z.ai API errors**
+1. **Alibaba Cloud Model Studio API errors**
 
    - **Symptom**: 401/403 from upstream provider
-   - **Resolution**: Verify `ZAI_API_KEY` in litellm-secrets. Check Z.ai subscription status and quota.
+   - **Resolution**: Verify `DASHSCOPE_API_KEY` in litellm-secrets. Check Alibaba Cloud Model Studio subscription status and quota.
 
 ## References
 
 - [LiteLLM Documentation](https://docs.litellm.ai/)
-- [LiteLLM Z.ai Provider](https://docs.litellm.ai/docs/providers/zhipuai)
+- [LiteLLM DashScope Provider](https://docs.litellm.ai/docs/providers/dashscope)
+- [Alibaba Cloud Model Studio](https://www.alibabacloud.com/en/product/model-studio)
 - [Claude Code LLM Gateway Docs](https://code.claude.com/docs/en/llm-gateway)
 - [PyPI Compromise Advisory](https://github.com/BerriAI/litellm/issues/24524)

--- a/cluster/apps/litellm/README.md
+++ b/cluster/apps/litellm/README.md
@@ -1,0 +1,85 @@
+# LiteLLM Proxy - Centralized LLM Gateway
+
+## Overview
+
+LiteLLM Proxy provides a centralized, OpenAI-compatible LLM gateway backed by Z.ai (Zhipu AI) GLM models. Replaces direct Anthropic API usage for Claude Code CLI automation, providing flat-rate pricing, virtual key management, spend tracking, and OTEL observability.
+
+## Prerequisites
+
+- authentik (SSO via OIDC Blueprint)
+- cnpg-operator (CloudNativePG)
+- external-secrets (cross-namespace OIDC credential sync)
+- plugin-barman-cloud (CNPG backup plugin)
+
+## Operations
+
+### Virtual Key Management
+
+Generate virtual keys after deployment via the LiteLLM admin UI (`https://litellm.<EXTERNAL_DOMAIN>`) or API:
+
+```bash
+curl -X POST "http://litellm.litellm.svc.cluster.local:4000/key/generate" \
+  -H "Authorization: Bearer <LITELLM_MASTER_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "key_alias": "n8n-automation",
+    "max_budget": 100,
+    "tpm_limit": 1000000,
+    "rpm_limit": 120
+  }'
+```
+
+Virtual keys are stored in PostgreSQL. Each consumer should have a dedicated key with appropriate budget and rate limits.
+
+| Consumer         | Secret Location                                       | Key Name               |
+| ---------------- | ----------------------------------------------------- | ---------------------- |
+| n8n agent pods   | `mcp-credentials` in each `claude-agents-*` namespace | `litellm-api-key`      |
+| Coder workspaces | Per-developer workspace secret or `.env`              | `ANTHROPIC_AUTH_TOKEN` |
+
+### Authentik SSO
+
+LiteLLM uses built-in OIDC SSO (not Authentik outpost). The OIDC provider and application are deployed declaratively via Authentik Blueprint (`blueprints/litellm-sso.yaml`). Credentials are synced cross-namespace via ExternalSecret (same pattern as Coder, Grafana, Vaultwarden).
+
+Blueprint creates:
+
+- Groups: `LiteLLM Users` (parent), `LiteLLM Admins` (child)
+- Provider: OAuth2/OIDC, confidential client
+- Application: slug `litellm`, redirect URI `/sso/callback`
+- Policy binding: restricts access to `LiteLLM Users` group members
+
+### Known Issues
+
+| Issue                 | Description                                            | Mitigation                                      |
+| --------------------- | ------------------------------------------------------ | ----------------------------------------------- |
+| BerriAI/litellm#25868 | Tool results silently dropped (list-format content)    | Monitor, wait for upstream fix                  |
+| BerriAI/litellm#27839 | Multi-turn conversations may get stuck                 | Retry logic in consumers                        |
+| Claude Code cost_usd  | Broken — internal price table only knows Claude models | Use LiteLLM Grafana dashboard for cost tracking |
+| Cache tokens          | Zero — GLM has no prompt caching                       | Expected behavior                               |
+
+### Security: PyPI Supply Chain Advisory
+
+LiteLLM PyPI versions 1.82.7-1.82.8 were compromised. **NEVER install from PyPI.** Docker/GHCR images were NOT affected. Always pin to a specific version tag with digest.
+
+## Troubleshooting
+
+1. **LiteLLM fails to start — database connection error**
+
+   - **Symptom**: Pod CrashLoopBackOff, logs show "connection refused" to PostgreSQL
+   - **Resolution**: Verify CNPG cluster is healthy: `kubectl get cluster -n litellm`. The CNPG cluster must be `Ready` before LiteLLM starts. Check that `litellm-cnpg-cluster-app` secret exists.
+
+1. **SSO redirect loop**
+
+   - **Symptom**: Login redirects endlessly between LiteLLM and Authentik
+   - **Resolution**: Verify `PROXY_BASE_URL` matches the IngressRoute hostname exactly. Check Authentik Application redirect URI includes `/sso/callback`.
+
+1. **Z.ai API errors**
+
+   - **Symptom**: 401/403 from upstream provider
+   - **Resolution**: Verify `ZAI_API_KEY` in litellm-secrets. Check Z.ai subscription status and quota.
+
+## References
+
+- [LiteLLM Documentation](https://docs.litellm.ai/)
+- [LiteLLM Z.ai Provider](https://docs.litellm.ai/docs/providers/zhipuai)
+- [Claude Code LLM Gateway Docs](https://code.claude.com/docs/en/llm-gateway)
+- [PyPI Compromise Advisory](https://github.com/BerriAI/litellm/issues/24524)

--- a/cluster/apps/litellm/kustomization.yaml
+++ b/cluster/apps/litellm/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./litellm/ks.yaml

--- a/cluster/apps/litellm/litellm/app/authentik-secret-store.yaml
+++ b/cluster/apps/litellm/litellm/app/authentik-secret-store.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/serviceaccount-v1.json
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: authentik-secret-reader
+  namespace: litellm
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/external-secrets.io/secretstore_v1.json
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: litellm-oauth-store
+  namespace: litellm
+spec:
+  provider:
+    kubernetes:
+      remoteNamespace: authentik-system
+      server:
+        url: "https://kubernetes.default.svc"
+        caProvider:
+          type: ConfigMap
+          name: kube-root-ca.crt
+          key: ca.crt
+      auth:
+        serviceAccount:
+          name: authentik-secret-reader

--- a/cluster/apps/litellm/litellm/app/kustomization.yaml
+++ b/cluster/apps/litellm/litellm/app/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ./litellm-cnpg-cluster.yaml
   - ./litellm-cnpg-scheduled-backups.yaml
   - ./network-policies.yaml
+  - ./oauth-rotation-rbac.yaml
   - ./release.yaml
   - ./vm-service-scrape.yaml
   - ./vpa.yaml

--- a/cluster/apps/litellm/litellm/app/kustomization.yaml
+++ b/cluster/apps/litellm/litellm/app/kustomization.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./authentik-secret-store.yaml
+  - ./litellm-oauth-external-secret.yaml
+  - ./litellm-secrets.sops.yaml
+  - ./litellm-cnpg-object-stores.yaml
+  - ./litellm-cnpg-cluster.yaml
+  - ./litellm-cnpg-scheduled-backups.yaml
+  - ./network-policies.yaml
+  - ./release.yaml
+  - ./vm-service-scrape.yaml
+  - ./vpa.yaml
+configMapGenerator:
+  - name: litellm-values
+    namespace: litellm
+    files:
+      - values.yaml
+configurations:
+  - ./kustomizeconfig.yaml

--- a/cluster/apps/litellm/litellm/app/kustomizeconfig.yaml
+++ b/cluster/apps/litellm/litellm/app/kustomizeconfig.yaml
@@ -1,0 +1,7 @@
+---
+nameReference:
+  - kind: ConfigMap
+    version: v1
+    fieldSpecs:
+      - path: spec/valuesFrom/name
+        kind: HelmRelease

--- a/cluster/apps/litellm/litellm/app/litellm-cnpg-cluster.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-cnpg-cluster.yaml
@@ -1,0 +1,42 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: litellm-cnpg-cluster
+spec:
+  bootstrap:
+    initdb:
+      database: litellm
+      owner: litellm
+  enableSuperuserAccess: true
+  imageName: "ghcr.io/cloudnative-pg/postgresql:18@sha256:664ebfe87d1cda6f429613d265ae1db758eb19ee050a2752ac38e856b0bd24ad"
+  instances: 2
+  monitoring:
+    enablePodMonitor: true
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      enabled: true
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: litellm-cnpg-aws-object-store
+  postgresql:
+    parameters:
+      shared_buffers: 128MB
+  primaryUpdateMethod: switchover
+  primaryUpdateStrategy: unsupervised
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
+  storage:
+    pvcTemplate:
+      storageClassName: rbd-fast-delete
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 2Gi

--- a/cluster/apps/litellm/litellm/app/litellm-cnpg-object-stores.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-cnpg-object-stores.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/barmancloud.cnpg.io/objectstore_v1.json
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: litellm-cnpg-aws-object-store
+spec:
+  retentionPolicy: 7d
+  configuration:
+    destinationPath: s3://spruyt-labs-470715245270-prod-cnpg-backup/object-store
+    s3Credentials:
+      accessKeyId:
+        name: litellm-secrets
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: litellm-secrets
+        key: AWS_SECRET_ACCESS_KEY
+    data:
+      compression: bzip2
+    wal:
+      compression: bzip2
+      maxParallel: 8

--- a/cluster/apps/litellm/litellm/app/litellm-cnpg-scheduled-backups.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-cnpg-scheduled-backups.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: litellm-cnpg-daily-scheduled-backup
+spec:
+  immediate: true
+  suspend: false
+  schedule: "0 16 * * *"
+  cluster:
+    name: litellm-cnpg-cluster
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+  backupOwnerReference: self

--- a/cluster/apps/litellm/litellm/app/litellm-oauth-external-secret.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-oauth-external-secret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm-oauth-credentials
+  namespace: litellm
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: SecretStore
+    name: litellm-oauth-store
+  target:
+    name: litellm-oauth-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: GENERIC_CLIENT_ID
+      remoteRef:
+        key: authentik-litellm-oauth
+        property: LITELLM_OAUTH_CLIENT_ID
+    - secretKey: GENERIC_CLIENT_SECRET
+      remoteRef:
+        key: authentik-litellm-oauth
+        property: LITELLM_OAUTH_CLIENT_SECRET

--- a/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
@@ -1,0 +1,28 @@
+# yamllint disable
+apiVersion: v1
+kind: Secret
+metadata:
+    name: litellm-secrets
+type: Opaque
+stringData:
+    ZAI_API_KEY: ENC[AES256_GCM,data:bs1saS2PwEcnXYUqf0s4i/DLnA7QauQanfTiSgUjzIsN+sb7Pg/yA26n0TmCT+YRlw==,iv:u14TztaZpJhqZV6hja25qinAKrPtz2u6JWHMlx0JhWM=,tag:UlY8Uyf4p+oUpHyhFRaf2w==,type:str]
+    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:KroNBTSS6q6bumWxJP+cElV3AfE/E2G1XuJLFgPf0YD1TJQ=,iv:Pnmzi8FJnXta6ox7hOWhhatTtSLVF1k14p24giqg2h4=,tag:+qYM8yr3+54ZRULNzlJfpQ==,type:str]
+    LITELLM_SALT_KEY: ENC[AES256_GCM,data:FA32nVFfbFQIZCEG9YF+5A==,iv:ipMY6iD9+oxNQizQWeTeDVHMQVaYEpZeWAXiLav28dU=,tag:nHfS3dz2zzwVl8xWGfyg0g==,type:str]
+    #ENC[AES256_GCM,data:hjact94TrdYVhAW5eW56K5DJHVc3R4oH0uw/MLRxNa8L2sle,iv:i3LooSSm8sktX9ft5sQCDscoCl3fCnrNOnK9s3XaXC4=,tag:FqfEeLYaPecXt4nlLlVTww==,type:comment]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:XS8sdx0DJ1NR/LWXYaiR1rhyd0M=,iv:YfqVfn4PoqPANzgUudAtSsIk10cpGZXRsrhSccouRac=,tag:8RmgdU1FI+j+jS1bmwL7Bg==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:gKwYO4EGfMmHVKsnPFxrc53UxT5ZWp42oaU9Gr9ROQKfNJNMSAgktw==,iv:9vtrV11OblKocCrTwa4VaQ6jJ5cvcLLAYZIBnkfm2uY=,tag:b98/M5VsxTbMWEbs+X56lA==,type:str]
+sops:
+    age:
+        - recipient: age1lt4xakktwyjvsqe6e09ca8f7nsljua3lynd7d9lzcs39fyqt8ggq87glw5
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRN3A0SjlWNWxLbXQ2QXcx
+            bjZkckxYbGlOVHU0bDN1bEF2V1FIYWt0K1RrCjFEKzZFSXAxQS9oTDZadFNqOHdY
+            Unczc3VVbm5QK09nR01VRlVYTHJmZ3cKLS0tIFpvQVhyUllhb1p2eVRkMnRlUEha
+            RXNqQWxtWjUrNWVvaVZxRjFxYlR2YlUKqBDS9cZm17fiRIPqj7l1JrtwvU+K1cO+
+            7aBDzM9pZIBXR17CEM5IbIZpk70TX2XCqO4eNCfQXRP8AJursw0rww==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-15T03:57:19Z"
+    mac: ENC[AES256_GCM,data:11L7aIk1c6JU38io2dgTad01EDA904lR3ZZN0F/6dnqgwrkbKcQHLuTFT56v5aIamwUKuM3rBGwGPOmLh7CepCJygXtXuRCalkId4eeqkjE+74ZrcK4HkJ2NHetYefHxbKJivC8rWERDqezlTh3Ri6NMSmjuVLnbZZxZzhktxEk=,iv:iPd48iYLLvhq9I9xe7IRS/IOPDCQsg/iY72Suk4dQeY=,tag:lKSJOsstyav6fIlUV1coKQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
@@ -5,24 +5,25 @@ metadata:
     name: litellm-secrets
 type: Opaque
 stringData:
-    ZAI_API_KEY: ENC[AES256_GCM,data:bs1saS2PwEcnXYUqf0s4i/DLnA7QauQanfTiSgUjzIsN+sb7Pg/yA26n0TmCT+YRlw==,iv:u14TztaZpJhqZV6hja25qinAKrPtz2u6JWHMlx0JhWM=,tag:UlY8Uyf4p+oUpHyhFRaf2w==,type:str]
-    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:KroNBTSS6q6bumWxJP+cElV3AfE/E2G1XuJLFgPf0YD1TJQ=,iv:Pnmzi8FJnXta6ox7hOWhhatTtSLVF1k14p24giqg2h4=,tag:+qYM8yr3+54ZRULNzlJfpQ==,type:str]
-    LITELLM_SALT_KEY: ENC[AES256_GCM,data:FA32nVFfbFQIZCEG9YF+5A==,iv:ipMY6iD9+oxNQizQWeTeDVHMQVaYEpZeWAXiLav28dU=,tag:nHfS3dz2zzwVl8xWGfyg0g==,type:str]
-    #ENC[AES256_GCM,data:hjact94TrdYVhAW5eW56K5DJHVc3R4oH0uw/MLRxNa8L2sle,iv:i3LooSSm8sktX9ft5sQCDscoCl3fCnrNOnK9s3XaXC4=,tag:FqfEeLYaPecXt4nlLlVTww==,type:comment]
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:XS8sdx0DJ1NR/LWXYaiR1rhyd0M=,iv:YfqVfn4PoqPANzgUudAtSsIk10cpGZXRsrhSccouRac=,tag:8RmgdU1FI+j+jS1bmwL7Bg==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:gKwYO4EGfMmHVKsnPFxrc53UxT5ZWp42oaU9Gr9ROQKfNJNMSAgktw==,iv:9vtrV11OblKocCrTwa4VaQ6jJ5cvcLLAYZIBnkfm2uY=,tag:b98/M5VsxTbMWEbs+X56lA==,type:str]
+    #ENC[AES256_GCM,data:sRRrpEVd/4WQSZuXj7Lph4lbtUfai5B2sc2Hs4oEcwzQNlLW,iv:WhXvjpHVSoNn5hY9ByGDLLJbsZs56LQ0uJ4JYhkPPyE=,tag:h/nn1+G2tAab51yf5ZhQIg==,type:comment]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:YKN22wxPAvAeHseRAA1XzdMTKSc=,iv:OzOr5/vS2cx+v08Y0HEXZx/x/OHk9D4iiJ2xmY2NJq0=,tag:tUSiI5oQcJ/94k6oRJ938Q==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:2QzLrtRuipYsr2piU5uK8Sbu1Diu994D9mt1XzVZZf9/WoYtgW30IA==,iv:l4xMmRAzfIBLjSRi64dGN86QcUPnqDpEn4Z1uuVdXcU=,tag:JKfbAv8pyiy/kX5GbrP+ng==,type:str]
+    DASHSCOPE_API_KEY: ENC[AES256_GCM,data:7nSitbchEIuXO2pQGUe8ZuxNqnvo7Nps81m1xK+CeW0FpWwAvPDKgkZLG4Drg1orqUysfn39VQqev6s390/2uHHAZjy02uwIQ1j9tYQu1uIIjS0KqUfpy6VAKnVen5PC3Vlml6yoHwIybtaEQU0kFf9XyNmvVldLbYiXSWbmRgxD9lVfGSr9VIwoOsENeFPywQmftg78qpngtYhLHoP3ANn10I9M/u1USsS7LtoHm7sanrf229Cinm9+SaVaqH1WEldK3F2ag2FPY8iyKrmFltofPUS4vcBfbYEb23ISgM1XjIRNEf/LuMNYc8zcVdIrsFItOLlPTzIrCunjITTaE7sq5Vdkhti605giQZ+f51iJU78HNw==,iv:OnlbQDr/RKERkG35Bnkl+jIz/Iwc4RsmU/JZ+bsF4oc=,tag:3AdTqc53gFZHrne6n9N77Q==,type:str]
+    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:O0RXysVQWSKvM38TJChQO2t6H8A28bAghtE0RQRRXPBFe3w=,iv:1nVn7mGBZ3LF0uGuFZjST1eIbVLGOd3jluhz8o19YZA=,tag:0aNFVQOb3bTtij2HXzhVtw==,type:str]
+    LITELLM_SALT_KEY: ENC[AES256_GCM,data:mmDmFgQoL2Sb7/eTf6jrrw==,iv:M2tCJo0LqTU3A1SZ2hg7uLdTL5ig9LvU6QhzXpLTynw=,tag:Aspcx8AKlpLPk3+pODht5g==,type:str]
+    ZAI_API_KEY: ENC[AES256_GCM,data:Q/o1dDVLNGbsajEyfzAog2ga6Vn7rosiWe/IynnzLoZ5i8FEeL+2SQIhgVjvXttIrw==,iv:fIjkJ+C2oIP1jBzBo1zwjZUKj98rUzb+GPiBvo70uAc=,tag:kOGk8v+bhn+fABC5D4+Cyg==,type:str]
 sops:
     age:
         - recipient: age1lt4xakktwyjvsqe6e09ca8f7nsljua3lynd7d9lzcs39fyqt8ggq87glw5
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRN3A0SjlWNWxLbXQ2QXcx
-            bjZkckxYbGlOVHU0bDN1bEF2V1FIYWt0K1RrCjFEKzZFSXAxQS9oTDZadFNqOHdY
-            Unczc3VVbm5QK09nR01VRlVYTHJmZ3cKLS0tIFpvQVhyUllhb1p2eVRkMnRlUEha
-            RXNqQWxtWjUrNWVvaVZxRjFxYlR2YlUKqBDS9cZm17fiRIPqj7l1JrtwvU+K1cO+
-            7aBDzM9pZIBXR17CEM5IbIZpk70TX2XCqO4eNCfQXRP8AJursw0rww==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKN0ZCTEhjWXpYQllXWHNE
+            MWNrR054Y3E1NDVvbDdxcEN3aWJOMnV3VUdRClRLSzE4Qk10by9rUmp0SDdhdk1T
+            aXVuUi9WMndpT2F3aWxMVDh4RlpPVGsKLS0tIG1DYUt1Vm9RT09CODgzZ1A1amFr
+            M09Icm5qV3N3N2w2Z2xSL2c2cFBMa28KKaxIyNY07OxeRyR8MEPVDi+jXhxsvSZ0
+            Vb1uhvYkMdhiPU+bKLsu+Fz+MWU0uf/J1e0u+yPN6APYjS7BhVuFOw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T03:57:19Z"
-    mac: ENC[AES256_GCM,data:11L7aIk1c6JU38io2dgTad01EDA904lR3ZZN0F/6dnqgwrkbKcQHLuTFT56v5aIamwUKuM3rBGwGPOmLh7CepCJygXtXuRCalkId4eeqkjE+74ZrcK4HkJ2NHetYefHxbKJivC8rWERDqezlTh3Ri6NMSmjuVLnbZZxZzhktxEk=,iv:iPd48iYLLvhq9I9xe7IRS/IOPDCQsg/iY72Suk4dQeY=,tag:lKSJOsstyav6fIlUV1coKQ==,type:str]
+    lastmodified: "2026-05-15T07:42:49Z"
+    mac: ENC[AES256_GCM,data:GondRfLcLUSKFL4YqCRRZt2x7QboK632uAQdF7iBh82165xt/OeRTIVZGZC8mYuODeJdTRB6sS8rhRscr27atOfZkni5yxvqz8Df9UsfwhtidzZEvZIH8uj3e/K+Hnofg6HpKlj+eD9O7HCIFQPsCKgPXTGtKSOHQwthu265gcM=,iv:pcA6lWphGA5XQT/SLbyKhY4PqDDUrMb3MEtqVeQJ+Vk=,tag:89UlT0/BvjGIBw1KXjv10Q==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
+++ b/cluster/apps/litellm/litellm/app/litellm-secrets.sops.yaml
@@ -5,25 +5,27 @@ metadata:
     name: litellm-secrets
 type: Opaque
 stringData:
-    #ENC[AES256_GCM,data:sRRrpEVd/4WQSZuXj7Lph4lbtUfai5B2sc2Hs4oEcwzQNlLW,iv:WhXvjpHVSoNn5hY9ByGDLLJbsZs56LQ0uJ4JYhkPPyE=,tag:h/nn1+G2tAab51yf5ZhQIg==,type:comment]
-    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:YKN22wxPAvAeHseRAA1XzdMTKSc=,iv:OzOr5/vS2cx+v08Y0HEXZx/x/OHk9D4iiJ2xmY2NJq0=,tag:tUSiI5oQcJ/94k6oRJ938Q==,type:str]
-    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:2QzLrtRuipYsr2piU5uK8Sbu1Diu994D9mt1XzVZZf9/WoYtgW30IA==,iv:l4xMmRAzfIBLjSRi64dGN86QcUPnqDpEn4Z1uuVdXcU=,tag:JKfbAv8pyiy/kX5GbrP+ng==,type:str]
-    DASHSCOPE_API_KEY: ENC[AES256_GCM,data:7nSitbchEIuXO2pQGUe8ZuxNqnvo7Nps81m1xK+CeW0FpWwAvPDKgkZLG4Drg1orqUysfn39VQqev6s390/2uHHAZjy02uwIQ1j9tYQu1uIIjS0KqUfpy6VAKnVen5PC3Vlml6yoHwIybtaEQU0kFf9XyNmvVldLbYiXSWbmRgxD9lVfGSr9VIwoOsENeFPywQmftg78qpngtYhLHoP3ANn10I9M/u1USsS7LtoHm7sanrf229Cinm9+SaVaqH1WEldK3F2ag2FPY8iyKrmFltofPUS4vcBfbYEb23ISgM1XjIRNEf/LuMNYc8zcVdIrsFItOLlPTzIrCunjITTaE7sq5Vdkhti605giQZ+f51iJU78HNw==,iv:OnlbQDr/RKERkG35Bnkl+jIz/Iwc4RsmU/JZ+bsF4oc=,tag:3AdTqc53gFZHrne6n9N77Q==,type:str]
-    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:O0RXysVQWSKvM38TJChQO2t6H8A28bAghtE0RQRRXPBFe3w=,iv:1nVn7mGBZ3LF0uGuFZjST1eIbVLGOd3jluhz8o19YZA=,tag:0aNFVQOb3bTtij2HXzhVtw==,type:str]
-    LITELLM_SALT_KEY: ENC[AES256_GCM,data:mmDmFgQoL2Sb7/eTf6jrrw==,iv:M2tCJo0LqTU3A1SZ2hg7uLdTL5ig9LvU6QhzXpLTynw=,tag:Aspcx8AKlpLPk3+pODht5g==,type:str]
-    ZAI_API_KEY: ENC[AES256_GCM,data:Q/o1dDVLNGbsajEyfzAog2ga6Vn7rosiWe/IynnzLoZ5i8FEeL+2SQIhgVjvXttIrw==,iv:fIjkJ+C2oIP1jBzBo1zwjZUKj98rUzb+GPiBvo70uAc=,tag:kOGk8v+bhn+fABC5D4+Cyg==,type:str]
+    #ENC[AES256_GCM,data:t2XAeFHQeSnIOktpuZEUTgq82cdLFve1A06pXPiyb/F8+EqZ,iv:Th0859r+YmgAxDEs30NdID9CVUqBSFg+j7X26X3VYGA=,tag:f7EqFdOdHOT9UWh6VME2hQ==,type:comment]
+    AWS_ACCESS_KEY_ID: ENC[AES256_GCM,data:s+sVBVxogOACvhDn9Fz/89y9jW8=,iv:PVQAedUEXyj4icvG0e3+Y0UxqeVxWyNjMIVb+gF/75A=,tag:Gwhq79vvK9yj6E82CBsDtQ==,type:str]
+    AWS_SECRET_ACCESS_KEY: ENC[AES256_GCM,data:VN052AY/7FFaYs9URw7wOih/qROzgE62iovjPqD3kpALowgJP5E4Fg==,iv:i1lZYfMC9oEYYq6350YYp4nZrQxEEeUQGK7z0Xz5m2g=,tag:/Z46GbUACju/cpe+SU/HSw==,type:str]
+    DASHSCOPE_API_KEY: ENC[AES256_GCM,data:HgvdKzuIV8WjMg8/qDEUm2cCe+/vWU1h4nnj6wtvoErfuaWG+6MpSCl2Mnbzwt7BUhId4dJXbgswzzMGGPoKWEbkAdnd4m/iohLW4mzEp2qPhSHmxB/xI3OMcNyLP3qX3TD60+iI42tyYq/FsPv3ZVvIhl7tsmnhoXgnyt0XCJpFYOwAF+tV5wItewWw6fDmkdNgfSFdlLox9m4JfWgp3sHwabVhhEzLSNIpadjNgJkld63T9T2QzsSLF9g0GaG4J3o8SdRNqcocN4InELwmmoWxBYKQpsQuRwODaxVeWtOd/Grk3z/DZGu+tIb7YVcXKfq6s8ldrPzRhe5AJzE0FNzb3uWhRqyjeGkBaJe72sNYHVKrIw==,iv:GozewWcxorHLYDgwddYh5qPBtaiCZCo4AFp6zQS4Wss=,tag:JVJS84CC6YnUVhZIxwpaYQ==,type:str]
+    GEMINI_API_KEY: ENC[AES256_GCM,data:yZaIVxNBQPRmW65/5UE826hi2a91HEBQbAIS/93/8cLXZ2a6rspolI+VFHeInp0Eof75BEA=,iv:gQGqph+EVD7mKpSeD+F4JMv/5ng5Mvh8vZM32mEjGCs=,tag:6WRj8K96SiQZL8FQjmDbyA==,type:str]
+    LITELLM_MASTER_KEY: ENC[AES256_GCM,data:i6d2lk8jYrpZR/SzoVMXu1Oey0kUOgWLSwqwGL6LjOcMIOw=,iv:nNzXDuXov0yBRzCQD2v6/1QczpDImoXZU/BnQDDRfEE=,tag:o5Z8xNpzAS/AXTVtmqqvVQ==,type:str]
+    LITELLM_SALT_KEY: ENC[AES256_GCM,data:yas/YkmpU4DRskkD7gqC7w==,iv:9hGnNM1kK6Ob4fee284LtqKJpwi2CYe6mzaS2fqCubc=,tag:h+0TN9OBQ0Ad5mRCaSu3dg==,type:str]
+    OPENAI_API_KEY: ENC[AES256_GCM,data:JEqoWWSim8ZzC7pprZK4DZ5tAEl+fPCiCBNCwja69QsOQzGQtvJTkdi0/A0bNZaBhz6r6U3AOIvLzcxFpCwT/cxprbiorMoQRLHdei38T7mSVUkreZvduyHZAW/cu8/73k56n/U1rt0XpM41CD0D5d9u74Q3QpdtQ3ObtBbBcb4PutZLgQNn2d7W9f6cPQsZSplSgJl5fC/NqJEBBzy1uW353VV+YTQ=,iv:vEeNIZG+7K7xoZQTMBpMhpbtAMZ6PamUFF/szdPc2Lg=,tag:Vi/MKbIcO/Zgiu442xqQGw==,type:str]
+    ZAI_API_KEY: ENC[AES256_GCM,data:EObRj3hDU2TMpO35Q/jfs77k++HapFeANqD09Vasqom+UnHQvmrmzKccPiiWrTRfnw==,iv:hiTf+H49q5oZtViT67xW2ZgoTz07DRZJbgc85oABBQ0=,tag:bbAN51bWAqGCqkH6s7LfvQ==,type:str]
 sops:
     age:
         - recipient: age1lt4xakktwyjvsqe6e09ca8f7nsljua3lynd7d9lzcs39fyqt8ggq87glw5
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKN0ZCTEhjWXpYQllXWHNE
-            MWNrR054Y3E1NDVvbDdxcEN3aWJOMnV3VUdRClRLSzE4Qk10by9rUmp0SDdhdk1T
-            aXVuUi9WMndpT2F3aWxMVDh4RlpPVGsKLS0tIG1DYUt1Vm9RT09CODgzZ1A1amFr
-            M09Icm5qV3N3N2w2Z2xSL2c2cFBMa28KKaxIyNY07OxeRyR8MEPVDi+jXhxsvSZ0
-            Vb1uhvYkMdhiPU+bKLsu+Fz+MWU0uf/J1e0u+yPN6APYjS7BhVuFOw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBuV0pjYmtYd05WOW02bEk5
+            QTVVejdiYnlyTTZYUXBaUlRQa2hmTE4zNG1BCmtWaXpwdGFUVm9EOGJET3NGUmo3
+            RWpKcFdDTGw3SllDVHphTE5aTjQySk0KLS0tIEhIYmNZWnA3cWpjTmhCN25NOVk5
+            UzZqL0NBVGJtano3UGdKdzhXTDA4MWcKpNg/ZiL4v80Gej/+WTn2hfLU4pOGeUYm
+            yemhT3cwpZqwkEGYr8KLB4ULNjslxCMwIIapf6/CY64AwLd0ISw1Jw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-15T07:42:49Z"
-    mac: ENC[AES256_GCM,data:GondRfLcLUSKFL4YqCRRZt2x7QboK632uAQdF7iBh82165xt/OeRTIVZGZC8mYuODeJdTRB6sS8rhRscr27atOfZkni5yxvqz8Df9UsfwhtidzZEvZIH8uj3e/K+Hnofg6HpKlj+eD9O7HCIFQPsCKgPXTGtKSOHQwthu265gcM=,iv:pcA6lWphGA5XQT/SLbyKhY4PqDDUrMb3MEtqVeQJ+Vk=,tag:89UlT0/BvjGIBw1KXjv10Q==,type:str]
+    lastmodified: "2026-05-15T08:19:15Z"
+    mac: ENC[AES256_GCM,data:mHk96C78Nm/gyMe4B4fusaTG/JIr5gETL0NEQs158ORxTnC4j+hUVYcEkX3W9vwTgpm/3LJpkrMcKH9ZrJP8mZccsdgEx+mOTeDJVGF7xKSQsEoRweFsU22zRMzKGW3QqsHuangHKsbmvMKEgw6JmrAucAP9oxIodITvKw3gQIs=,iv:55m/Pm4hHItCRcMkg+3RLKSz1jXSJN+w2KJlnZJ72fw=,tag:8xBQzZE45q7BnaljrXO5bw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.12.2

--- a/cluster/apps/litellm/litellm/app/network-policies.yaml
+++ b/cluster/apps/litellm/litellm/app/network-policies.yaml
@@ -1,0 +1,316 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# =============================================================================
+# LiteLLM Proxy Policies
+# =============================================================================
+# DNS egress is handled by CiliumClusterwideNetworkPolicy allow-kube-dns-egress
+# Allow ingress from Traefik for admin UI and external API access
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-traefik-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: traefik
+            k8s:app.kubernetes.io/name: traefik
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow ingress from Claude agent pods (all namespaces)
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-claude-agents-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-agents-read
+            k8s:managed-by: n8n-claude-code
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-agents-spruyt-labs-read
+            k8s:managed-by: n8n-claude-code
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-agents-spruyt-labs-sre
+            k8s:managed-by: n8n-claude-code
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-agents-spruyt-labs-write
+            k8s:managed-by: n8n-claude-code
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: claude-agents-write
+            k8s:managed-by: n8n-claude-code
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow ingress from Coder workspaces
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-coder-workspaces-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: coder-workspaces
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to CNPG PostgreSQL
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-postgres-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: litellm
+            k8s:cnpg.io/cluster: litellm-cnpg-cluster
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to Z.ai API and Authentik OIDC endpoints
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-world-https-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to OTEL endpoints in observability namespace
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-otel-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+      toPorts:
+        - ports:
+            - port: "8428"
+              protocol: TCP
+            - port: "9428"
+              protocol: TCP
+            - port: "10428"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow metrics scraping from vmagent
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-metrics-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+            k8s:app.kubernetes.io/name: vmagent
+      toPorts:
+        - ports:
+            - port: "4000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# =============================================================================
+# CNPG PostgreSQL Cluster Policies
+# =============================================================================
+# DNS egress is handled by CiliumClusterwideNetworkPolicy allow-kube-dns-egress
+# Allow ingress from LiteLLM for database connections
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-litellm-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: litellm
+            k8s:app.kubernetes.io/name: litellm
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow internal cluster communication for replication and status
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-internal-cluster
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: litellm
+            k8s:cnpg.io/cluster: litellm-cnpg-cluster
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+            - port: "8000"
+              protocol: TCP
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: litellm
+            k8s:cnpg.io/cluster: litellm-cnpg-cluster
+      toPorts:
+        - ports:
+            - port: "5432"
+              protocol: TCP
+            - port: "8000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow S3 backup uploads via Barman cloud plugin
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-world-https-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  egress:
+    - toEntities:
+        - world
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow metrics scraping from vmagent
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-metrics-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: observability
+            k8s:app.kubernetes.io/name: vmagent
+      toPorts:
+        - ports:
+            - port: "9187"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow CNPG operator access for cluster management
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-operator-ingress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+            k8s:app.kubernetes.io/name: cloudnative-pg
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow kube-api egress for cluster coordination
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-kube-api-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  egress:
+    - toEntities:
+        - kube-apiserver
+      toPorts:
+        - ports:
+            - port: "6443"
+              protocol: TCP
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cilium.io/ciliumnetworkpolicy_v2.json
+# Allow egress to Barman cloud plugin for backup operations
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-cnpg-barman-egress
+spec:
+  endpointSelector:
+    matchLabels:
+      cnpg.io/cluster: litellm-cnpg-cluster
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: cnpg-system
+            k8s:app.kubernetes.io/name: plugin-barman-cloud
+      toPorts:
+        - ports:
+            - port: "9090"
+              protocol: TCP

--- a/cluster/apps/litellm/litellm/app/oauth-rotation-rbac.yaml
+++ b/cluster/apps/litellm/litellm/app/oauth-rotation-rbac.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/role-rbac-v1.json
+# Role in litellm namespace to allow forcing ExternalSecret sync
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: oauth-secret-rotation
+  namespace: litellm
+rules:
+  - apiGroups: ["external-secrets.io"]
+    resources: ["externalsecrets"]
+    resourceNames: ["litellm-oauth-credentials"]
+    verbs: ["get", "patch"]
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/master-standalone-strict/rolebinding-rbac-v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: oauth-secret-rotation
+  namespace: litellm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: oauth-secret-rotation
+subjects:
+  - kind: ServiceAccount
+    name: oauth-secret-rotation
+    namespace: authentik-system

--- a/cluster/apps/litellm/litellm/app/release.yaml
+++ b/cluster/apps/litellm/litellm/app/release.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+    namespace: flux-system
+  interval: 4h
+  valuesFrom:
+    - kind: ConfigMap
+      name: litellm-values

--- a/cluster/apps/litellm/litellm/app/values.yaml
+++ b/cluster/apps/litellm/litellm/app/values.yaml
@@ -115,15 +115,14 @@ configMaps:
     data:
       config.yaml: |
         model_list:
-          # Recommended models
           - model_name: qwen3.6-plus
             litellm_params:
               model: openai/qwen3.6-plus
               api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
               api_key: os.environ/DASHSCOPE_API_KEY
-          - model_name: kimi-k2.5
+          - model_name: deepseek-v3.2
             litellm_params:
-              model: openai/kimi-k2.5
+              model: openai/deepseek-v3.2
               api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
               api_key: os.environ/DASHSCOPE_API_KEY
           - model_name: glm-5
@@ -134,32 +133,6 @@ configMaps:
           - model_name: MiniMax-M2.5
             litellm_params:
               model: openai/MiniMax-M2.5
-              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
-              api_key: os.environ/DASHSCOPE_API_KEY
-          # Additional models
-          - model_name: qwen3.5-plus
-            litellm_params:
-              model: openai/qwen3.5-plus
-              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
-              api_key: os.environ/DASHSCOPE_API_KEY
-          - model_name: qwen3-max-2026-01-23
-            litellm_params:
-              model: openai/qwen3-max-2026-01-23
-              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
-              api_key: os.environ/DASHSCOPE_API_KEY
-          - model_name: qwen3-coder-next
-            litellm_params:
-              model: openai/qwen3-coder-next
-              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
-              api_key: os.environ/DASHSCOPE_API_KEY
-          - model_name: qwen3-coder-plus
-            litellm_params:
-              model: openai/qwen3-coder-plus
-              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
-              api_key: os.environ/DASHSCOPE_API_KEY
-          - model_name: glm-4.7
-            litellm_params:
-              model: openai/glm-4.7
               api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
               api_key: os.environ/DASHSCOPE_API_KEY
         litellm_settings:

--- a/cluster/apps/litellm/litellm/app/values.yaml
+++ b/cluster/apps/litellm/litellm/app/values.yaml
@@ -42,12 +42,12 @@ controllers:
               secretKeyRef:
                 name: litellm-secrets
                 key: LITELLM_SALT_KEY
-          # Z.ai API key — referenced in proxy_config.yaml as os.environ/ZAI_API_KEY
-          ZAI_API_KEY:
+          # Alibaba Cloud Model Studio API key — referenced in proxy_config.yaml as os.environ/DASHSCOPE_API_KEY
+          DASHSCOPE_API_KEY:
             valueFrom:
               secretKeyRef:
                 name: litellm-secrets
-                key: ZAI_API_KEY
+                key: DASHSCOPE_API_KEY
           # Authentik SSO (OIDC) — credentials from ExternalSecret
           GENERIC_CLIENT_ID:
             valueFrom:
@@ -115,18 +115,53 @@ configMaps:
     data:
       config.yaml: |
         model_list:
-          - model_name: glm-5.1
+          # Recommended models
+          - model_name: qwen3.6-plus
             litellm_params:
-              model: zai/glm-5.1
-              api_key: os.environ/ZAI_API_KEY
+              model: openai/qwen3.6-plus
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: kimi-k2.5
+            litellm_params:
+              model: openai/kimi-k2.5
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: glm-5
+            litellm_params:
+              model: openai/glm-5
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: MiniMax-M2.5
+            litellm_params:
+              model: openai/MiniMax-M2.5
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          # Additional models
+          - model_name: qwen3.5-plus
+            litellm_params:
+              model: openai/qwen3.5-plus
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: qwen3-max-2026-01-23
+            litellm_params:
+              model: openai/qwen3-max-2026-01-23
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: qwen3-coder-next
+            litellm_params:
+              model: openai/qwen3-coder-next
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
+          - model_name: qwen3-coder-plus
+            litellm_params:
+              model: openai/qwen3-coder-plus
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
           - model_name: glm-4.7
             litellm_params:
-              model: zai/glm-4.7
-              api_key: os.environ/ZAI_API_KEY
-          - model_name: glm-4.5-flash
-            litellm_params:
-              model: zai/glm-4.5-flash
-              api_key: os.environ/ZAI_API_KEY
+              model: openai/glm-4.7
+              api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
+              api_key: os.environ/DASHSCOPE_API_KEY
         litellm_settings:
           drop_params: true
           callbacks:

--- a/cluster/apps/litellm/litellm/app/values.yaml
+++ b/cluster/apps/litellm/litellm/app/values.yaml
@@ -1,0 +1,148 @@
+---
+# Default values: https://github.com/bjw-s-labs/helm-charts/blob/main/charts/library/common/values.yaml
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/refs/tags/app-template-5.0.0/charts/library/common/values.schema.json
+controllers:
+  litellm:
+    type: deployment
+    replicas: 1
+    annotations:
+      reloader.stakater.com/auto: "true"
+    pod:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    containers:
+      litellm:
+        image:
+          # renovate: datasource=docker depName=ghcr.io/berriai/litellm-database
+          repository: ghcr.io/berriai/litellm-database
+          tag: v1.84.0
+          pullPolicy: IfNotPresent
+        args:
+          - "--config"
+          - "/app/config.yaml"
+          - "--port"
+          - "4000"
+        env:
+          # Database — CNPG auto-generated secret
+          DATABASE_URL:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-cnpg-cluster-app
+                key: uri
+          # LiteLLM core secrets
+          LITELLM_MASTER_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secrets
+                key: LITELLM_MASTER_KEY
+          LITELLM_SALT_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secrets
+                key: LITELLM_SALT_KEY
+          # Z.ai API key — referenced in proxy_config.yaml as os.environ/ZAI_API_KEY
+          ZAI_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secrets
+                key: ZAI_API_KEY
+          # Authentik SSO (OIDC) — credentials from ExternalSecret
+          GENERIC_CLIENT_ID:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-oauth-credentials
+                key: GENERIC_CLIENT_ID
+          GENERIC_CLIENT_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-oauth-credentials
+                key: GENERIC_CLIENT_SECRET
+          GENERIC_AUTHORIZATION_ENDPOINT: "https://auth.${EXTERNAL_DOMAIN}/application/o/authorize/"
+          GENERIC_TOKEN_ENDPOINT: "https://auth.${EXTERNAL_DOMAIN}/application/o/token/"
+          GENERIC_USERINFO_ENDPOINT: "https://auth.${EXTERNAL_DOMAIN}/application/o/userinfo/"
+          PROXY_BASE_URL: "https://litellm.${EXTERNAL_DOMAIN}"
+          # OTEL — LiteLLM uses standard OTEL SDK env vars
+          OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+          OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: http://vmsingle-victoria-metrics-k8s-stack.observability.svc:8428/opentelemetry/v1/metrics
+          OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://victoria-traces-single-vt-single-server.observability.svc:10428/insert/opentelemetry/v1/traces
+          OTEL_RESOURCE_ATTRIBUTES: "service.name=litellm,service.namespace=litellm"
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health/liveliness
+                port: 4000
+              initialDelaySeconds: 120
+              periodSeconds: 15
+              failureThreshold: 3
+              timeoutSeconds: 10
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health/readiness
+                port: 4000
+              initialDelaySeconds: 120
+              periodSeconds: 15
+              failureThreshold: 3
+              timeoutSeconds: 10
+        resources:
+          limits:
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
+service:
+  litellm:
+    controller: litellm
+    ports:
+      http:
+        port: 4000
+        protocol: TCP
+configMaps:
+  litellm-config:
+    data:
+      config.yaml: |
+        model_list:
+          - model_name: glm-5.1
+            litellm_params:
+              model: zai/glm-5.1
+              api_key: os.environ/ZAI_API_KEY
+          - model_name: glm-4.7
+            litellm_params:
+              model: zai/glm-4.7
+              api_key: os.environ/ZAI_API_KEY
+          - model_name: glm-4.5-flash
+            litellm_params:
+              model: zai/glm-4.5-flash
+              api_key: os.environ/ZAI_API_KEY
+        litellm_settings:
+          drop_params: true
+          callbacks:
+            - otel
+            - prometheus
+persistence:
+  tmp:
+    type: emptyDir
+    globalMounts:
+      - path: /tmp
+  config:
+    type: configMap
+    identifier: litellm-config
+    advancedMounts:
+      litellm:
+        litellm:
+          - path: /app/config.yaml
+            subPath: config.yaml
+            readOnly: true

--- a/cluster/apps/litellm/litellm/app/values.yaml
+++ b/cluster/apps/litellm/litellm/app/values.yaml
@@ -48,6 +48,18 @@ controllers:
               secretKeyRef:
                 name: litellm-secrets
                 key: DASHSCOPE_API_KEY
+          # Gemini API key
+          GEMINI_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secrets
+                key: GEMINI_API_KEY
+          # OpenAI API key
+          OPENAI_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secrets
+                key: OPENAI_API_KEY
           # Authentik SSO (OIDC) — credentials from ExternalSecret
           GENERIC_CLIENT_ID:
             valueFrom:
@@ -115,6 +127,7 @@ configMaps:
     data:
       config.yaml: |
         model_list:
+          # Alibaba Cloud Model Studio (DashScope)
           - model_name: qwen3.6-plus
             litellm_params:
               model: openai/qwen3.6-plus
@@ -135,6 +148,48 @@ configMaps:
               model: openai/MiniMax-M2.5
               api_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
               api_key: os.environ/DASHSCOPE_API_KEY
+          # OpenAI
+          - model_name: gpt-5.5
+            litellm_params:
+              model: gpt-5.5
+              api_key: os.environ/OPENAI_API_KEY
+          - model_name: gpt-5.5-pro
+            litellm_params:
+              model: gpt-5.5-pro
+              api_key: os.environ/OPENAI_API_KEY
+          - model_name: o4-mini
+            litellm_params:
+              model: o4-mini
+              api_key: os.environ/OPENAI_API_KEY
+          - model_name: o3-pro
+            litellm_params:
+              model: o3-pro
+              api_key: os.environ/OPENAI_API_KEY
+          - model_name: gpt-4.1
+            litellm_params:
+              model: gpt-4.1
+              api_key: os.environ/OPENAI_API_KEY
+          # Google Gemini
+          - model_name: gemini-3.1-pro-preview
+            litellm_params:
+              model: gemini/gemini-3.1-pro-preview
+              api_key: os.environ/GEMINI_API_KEY
+          - model_name: gemini-3.1-flash-lite-preview
+            litellm_params:
+              model: gemini/gemini-3.1-flash-lite-preview
+              api_key: os.environ/GEMINI_API_KEY
+          - model_name: gemini-2.5-pro
+            litellm_params:
+              model: gemini/gemini-2.5-pro
+              api_key: os.environ/GEMINI_API_KEY
+          - model_name: gemini-2.5-flash
+            litellm_params:
+              model: gemini/gemini-2.5-flash
+              api_key: os.environ/GEMINI_API_KEY
+          - model_name: gemini-2.0-flash
+            litellm_params:
+              model: gemini/gemini-2.0-flash
+              api_key: os.environ/GEMINI_API_KEY
         litellm_settings:
           drop_params: true
           callbacks:

--- a/cluster/apps/litellm/litellm/app/vm-service-scrape.yaml
+++ b/cluster/apps/litellm/litellm/app/vm-service-scrape.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/operator.victoriametrics.com/vmservicescrape_v1beta1.json
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: litellm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: litellm
+      app.kubernetes.io/name: litellm
+  namespaceSelector:
+    matchNames:
+      - litellm
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s

--- a/cluster/apps/litellm/litellm/app/vpa.yaml
+++ b/cluster/apps/litellm/litellm/app/vpa.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/autoscaling.k8s.io/verticalpodautoscaler_v1.json
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: litellm
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: litellm
+  updatePolicy:
+    updateMode: "Off"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: litellm
+        minAllowed:
+          cpu: 1m
+          memory: 1Mi
+        maxAllowed:
+          memory: 512Mi

--- a/cluster/apps/litellm/litellm/ks.yaml
+++ b/cluster/apps/litellm/litellm/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas-cjso.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: flux-system
+spec:
+  targetNamespace: litellm
+  path: ./cluster/apps/litellm/litellm/app
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: authentik
+    - name: cnpg-operator
+    - name: external-secrets
+    - name: plugin-barman-cloud
+  prune: true
+  timeout: 10m
+  wait: true

--- a/cluster/apps/litellm/namespace.yaml
+++ b/cluster/apps/litellm/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: litellm
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/cluster/apps/observability/victoria-metrics-k8s-stack/app/dashboards/litellm-proxy.json
+++ b/cluster/apps/observability/victoria-metrics-k8s-stack/app/dashboards/litellm-proxy.json
@@ -1,0 +1,827 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 20,
+    "links": [],
+    "panels": [
+      {
+        "collapsed": false,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 3,
+        "panels": [],
+        "title": "LiteLLM Proxy Level Metrics",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Total requests per second made to proxy - success + failure ",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 1
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m]))",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Proxy - Requests per second (success + failure)",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Failures per second by Exception Class",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 1
+        },
+        "id": 2,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum(rate(litellm_proxy_failed_requests_metric_total[2m])) by (exception_class)",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          }
+        ],
+        "title": "Proxy Failure Responses / Second By Exception Class",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Average Response latency (seconds)",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "sum(rate(litellm_request_total_latency_metric_sum[2m]))/sum(rate(litellm_request_total_latency_metric_count[2m]))"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Average Latency (seconds)"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "histogram_quantile(0.5, sum(rate(litellm_request_total_latency_metric_bucket[2m])) by (le))"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Median Latency (seconds)"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 9
+        },
+        "id": 5,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "code",
+            "expr": "sum(rate(litellm_request_total_latency_metric_sum[2m]))/sum(rate(litellm_request_total_latency_metric_count[2m]))",
+            "fullMetaSearch": false,
+            "includeNullMetadata": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.5, sum(rate(litellm_request_total_latency_metric_bucket[2m])) by (le))",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "Median latency seconds"
+          }
+        ],
+        "title": "Proxy - Average & Median Response Latency (seconds)",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 17
+        },
+        "id": 7,
+        "panels": [],
+        "title": "LLM API Metrics",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "x-ratelimit-remaining-requests returning from LLM APIs",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 18
+        },
+        "id": 6,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "expr": "topk(5, sort(litellm_remaining_requests))",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "x-ratelimit-remaining-requests",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "x-ratelimit-remaining-tokens from LLM API ",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": null
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 18
+        },
+        "id": 8,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "expr": "topk(5, sort(litellm_remaining_tokens))",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "x-ratelimit-remaining-tokens",
+        "type": "timeseries"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 26
+        },
+        "id": 4,
+        "panels": [],
+        "title": "LiteLLM Metrics by Virtual Key and Team",
+        "type": "row"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Requests per second by Key Alias (keys are LiteLLM Virtual Keys). If key is None - means no Alias Set ",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 27
+        },
+        "id": 9,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (api_key_alias)\n",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Requests per second by Key Alias",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "Requests per second by Team Alias. If team is None - means no team alias Set ",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 27
+        },
+        "id": 10,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.3.0-76761.patch01-77040",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "editorMode": "code",
+            "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (team_alias)\n",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Requests per second by Team Alias",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 40,
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "selected": false,
+            "text": "prometheus",
+            "value": "edx8memhpd9tsb"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "datasource",
+          "multi": false,
+          "name": "DS_PROMETHEUS",
+          "options": [],
+          "query": "prometheus",
+          "queryValue": "",
+          "refresh": 1,
+          "regex": "",
+          "skipUrlSync": false,
+          "type": "datasource"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "LiteLLM Prod v2",
+    "uid": "be059pwgrlg5cf",
+    "version": 17,
+    "weekStart": ""
+  }

--- a/cluster/apps/observability/victoria-metrics-k8s-stack/app/dashboards/litellm-proxy.json
+++ b/cluster/apps/observability/victoria-metrics-k8s-stack/app/dashboards/litellm-proxy.json
@@ -37,7 +37,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "Total requests per second made to proxy - success + failure ",
         "fieldConfig": {
@@ -119,7 +119,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -138,7 +138,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "Failures per second by Exception Class",
         "fieldConfig": {
@@ -220,7 +220,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -239,7 +239,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "Average Response latency (seconds)",
         "fieldConfig": {
@@ -346,7 +346,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "disableTextWrap": false,
             "editorMode": "code",
@@ -361,7 +361,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "editorMode": "code",
             "expr": "histogram_quantile(0.5, sum(rate(litellm_request_total_latency_metric_bucket[2m])) by (le))",
@@ -391,7 +391,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "x-ratelimit-remaining-requests returning from LLM APIs",
         "fieldConfig": {
@@ -473,7 +473,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "editorMode": "code",
             "expr": "topk(5, sort(litellm_remaining_requests))",
@@ -488,7 +488,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "x-ratelimit-remaining-tokens from LLM API ",
         "fieldConfig": {
@@ -570,7 +570,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "editorMode": "code",
             "expr": "topk(5, sort(litellm_remaining_tokens))",
@@ -598,7 +598,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "Requests per second by Key Alias (keys are LiteLLM Virtual Keys). If key is None - means no Alias Set ",
         "fieldConfig": {
@@ -679,7 +679,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "editorMode": "code",
             "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (api_key_alias)\n",
@@ -694,7 +694,7 @@
       {
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "${datasource}"
         },
         "description": "Requests per second by Team Alias. If team is None - means no team alias Set ",
         "fieldConfig": {
@@ -775,7 +775,7 @@
           {
             "datasource": {
               "type": "prometheus",
-              "uid": "${DS_PROMETHEUS}"
+              "uid": "${datasource}"
             },
             "editorMode": "code",
             "expr": "sum(rate(litellm_proxy_total_requests_metric_total[2m])) by (team_alias)\n",
@@ -803,7 +803,7 @@
           "includeAll": false,
           "label": "datasource",
           "multi": false,
-          "name": "DS_PROMETHEUS",
+          "name": "datasource",
           "options": [],
           "query": "prometheus",
           "queryValue": "",

--- a/cluster/apps/observability/victoria-metrics-k8s-stack/app/kustomization.yaml
+++ b/cluster/apps/observability/victoria-metrics-k8s-stack/app/kustomization.yaml
@@ -200,6 +200,14 @@ configMapGenerator:
     options:
       labels:
         grafana_dashboard: "1"
+  # LiteLLM proxy dashboard
+  - name: grafana-dashboard-litellm-proxy
+    namespace: observability
+    files:
+      - dashboards/litellm-proxy.json
+    options:
+      labels:
+        grafana_dashboard: "1"
   # Claude Code telemetry dashboard
   - name: grafana-dashboard-claude-code-telemetry
     namespace: observability

--- a/cluster/apps/traefik/traefik/ingress/kustomization.yaml
+++ b/cluster/apps/traefik/traefik/ingress/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ./foundryvtt
   - ./headlamp-system
   - ./kube-system
+  - ./litellm
   - ./minecraft
   - ./n8n-system
   - ./observability

--- a/cluster/apps/traefik/traefik/ingress/litellm/certificates.yaml
+++ b/cluster/apps/traefik/traefik/ingress/litellm/certificates.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: "litellm-${EXTERNAL_DOMAIN/./-}"
+  namespace: litellm
+spec:
+  secretName: "litellm-${EXTERNAL_DOMAIN/./-}-tls"
+  issuerRef:
+    name: ${CLUSTER_ISSUER}
+    kind: ClusterIssuer
+  dnsNames:
+    - "litellm.${EXTERNAL_DOMAIN}"

--- a/cluster/apps/traefik/traefik/ingress/litellm/ingress-routes.yaml
+++ b/cluster/apps/traefik/traefik/ingress/litellm/ingress-routes.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/traefik.io/ingressroute_v1alpha1.json
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: litellm-ingress-routes-wan-https
+  namespace: litellm
+  annotations:
+    cert-manager.io/cluster-issuer: ${CLUSTER_ISSUER}
+    external-dns.alpha.kubernetes.io/hostname: litellm.${EXTERNAL_DOMAIN}
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`litellm.${EXTERNAL_DOMAIN}`)
+      services:
+        - name: litellm
+          namespace: litellm
+          passHostHeader: true
+          port: 4000
+  tls:
+    secretName: "litellm-${EXTERNAL_DOMAIN/./-}-tls"

--- a/cluster/apps/traefik/traefik/ingress/litellm/kustomization.yaml
+++ b/cluster/apps/traefik/traefik/ingress/litellm/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./certificates.yaml
+  - ./ingress-routes.yaml

--- a/cluster/apps/traefik/traefik/ks.yaml
+++ b/cluster/apps/traefik/traefik/ks.yaml
@@ -33,6 +33,7 @@ spec:
     - name: firemerge
     - name: foundryvtt
     - name: headlamp
+    - name: litellm
     - name: n8n
     - name: n8n-mcp-server
     - name: nexus


### PR DESCRIPTION
## Summary

Deploy LiteLLM Proxy as a centralized LLM gateway backed by Z.ai, providing unified API access, cost tracking, and SSO authentication for all Claude agents and Coder workspaces.

## Linked Issue

Closes #1451

## Changes

- **Namespace & Flux structure**: New `litellm` namespace with PSA labels, Flux Kustomization with dependencies on authentik, cnpg-operator, external-secrets
- **CloudNativePG PostgreSQL**: 2-instance cluster (PostgreSQL 18) with Barman S3 WAL archiving, daily scheduled backups
- **SOPS secrets**: Encrypted secrets for Z.ai API key, LiteLLM master/salt keys, AWS backup credentials
- **Authentik SSO**: Blueprint with OAuth2 provider, groups (Users/Admins), policy binding; ExternalSecret for cross-namespace OIDC credential sync
- **LiteLLM deployment**: bjw-s app-template HelmRelease (v1.84.0) with Z.ai model config (glm-5.1, glm-4.7, glm-4.5-flash), health probes, OTEL callbacks
- **CiliumNetworkPolicies**: 15 zero-trust policies covering LiteLLM proxy and CNPG cluster traffic
- **Agent network egress**: Added LiteLLM egress policy to claude-agents-shared base
- **VPA**: Recommendation-only with 512Mi max memory
- **Observability**: VMServiceScrape for Prometheus metrics + upstream Grafana dashboard (datasource variable aligned to cluster convention)
- **IngressRoute**: Traefik route for `litellm.${EXTERNAL_DOMAIN}` with TLS certificate
- **Kyverno policy**: Inject ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, ANTHROPIC_MODEL into Claude agent pods
- **Coder template**: LiteLLM env vars added to devcontainer workspace template
- **OAuth rotation**: LiteLLM added to weekly oauth-secret-rotation CronJob with cross-namespace RBAC
- **README**: Component documentation with operations, troubleshooting, references

## Testing

- qa-validator passed on all changes (linting, schema validation, standards)
- Manual review of all 36 changed files
- Post-merge: cluster-validator will verify Flux reconciliation, pod health, and connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)