### PR TITLE
fix(agentmemory): bump engine/worker memory limits for OOMKill

### DIFF
--- a/cluster/apps/agentmemory/agentmemory/README.md
+++ b/cluster/apps/agentmemory/agentmemory/README.md
@@ -47,7 +47,7 @@ Engine pinned to `iiidev/iii:0.11.2` — v0.11.6+ breaks agentmemory. Track upst
 1. **Worker CrashLoopBackOff on first deploy**
 
    - **Symptom**: npx download times out or OOM during install
-   - **Resolution**: npm-registry-egress CNP must allow `registry.npmjs.org:443`. Check worker memory limit (512Mi) is sufficient for npx install.
+   - **Resolution**: npm-registry-egress CNP must allow `registry.npmjs.org:443`. Check worker memory limit (768Mi) is sufficient for npx install.
 
 1. **Viewer loads but API calls fail**
 

--- a/cluster/apps/agentmemory/agentmemory/README.md
+++ b/cluster/apps/agentmemory/agentmemory/README.md
@@ -47,7 +47,7 @@ Engine pinned to `iiidev/iii:0.11.2` — v0.11.6+ breaks agentmemory. Track upst
 1. **Worker CrashLoopBackOff on first deploy**
 
    - **Symptom**: npx download times out or OOM during install
-   - **Resolution**: npm-registry-egress CNP must allow `registry.npmjs.org:443`. Check worker memory limit (768Mi) is sufficient for npx install.
+   - **Resolution**: npm-registry-egress CNP must allow `registry.npmjs.org:443`.
 
 1. **Viewer loads but API calls fail**
 

--- a/cluster/apps/agentmemory/agentmemory/README.md
+++ b/cluster/apps/agentmemory/agentmemory/README.md
@@ -44,11 +44,6 @@ Engine pinned to `iiidev/iii:0.11.2` — v0.11.6+ breaks agentmemory. Track upst
 
 ## Troubleshooting
 
-1. **Worker CrashLoopBackOff on first deploy**
-
-   - **Symptom**: npx download times out or OOM during install
-   - **Resolution**: npm-registry-egress CNP must allow `registry.npmjs.org:443`.
-
 1. **Viewer loads but API calls fail**
 
    - **Symptom**: Browser shows viewer UI but searches return errors

--- a/cluster/apps/agentmemory/agentmemory/app/values.yaml
+++ b/cluster/apps/agentmemory/agentmemory/app/values.yaml
@@ -36,7 +36,7 @@ controllers:
             cpu: 10m
             memory: 256Mi
           limits:
-            memory: 768Mi
+            memory: 1280Mi
         probes:
           liveness:
             enabled: true
@@ -225,7 +225,7 @@ controllers:
             cpu: 10m
             memory: 128Mi
           limits:
-            memory: 512Mi
+            memory: 768Mi
         probes:
           liveness:
             enabled: true

--- a/cluster/apps/agentmemory/agentmemory/app/vpa.yaml
+++ b/cluster/apps/agentmemory/agentmemory/app/vpa.yaml
@@ -18,7 +18,7 @@ spec:
           cpu: 1m
           memory: 1Mi
         maxAllowed:
-          memory: 768Mi
+          memory: 1280Mi
       - containerName: console
         minAllowed:
           cpu: 1m
@@ -36,4 +36,4 @@ spec:
           cpu: 1m
           memory: 1Mi
         maxAllowed:
-          memory: 512Mi
+          memory: 768Mi


### PR DESCRIPTION
## Summary
- Engine memory limit 768Mi → 1280Mi (VPA uncapped target ~1050Mi, was OOMKilling at 781MB)
- Worker memory limit 512Mi → 768Mi (VPA uncapped target ~560Mi, preemptive)
- VPA maxAllowed updated to match new limits
- Removed stale first-deploy troubleshooting entry from README

## Linked Issue
Closes #1518

## Changes
- `cluster/apps/agentmemory/agentmemory/app/values.yaml` — bump engine + worker memory limits
- `cluster/apps/agentmemory/agentmemory/app/vpa.yaml` — bump VPA maxAllowed to match
- `cluster/apps/agentmemory/agentmemory/README.md` — remove stale troubleshooting entry

## Testing
- VPA recommendations confirm engine needs ~1050Mi uncapped
- qa-validator passed (MegaLinter, dry-run, schema validation)
- Limits/VPA maxAllowed alignment verified