### PR TITLE
fix(agentmemory): bump engine memory to 1536Mi and restart every 12h

### DIFF
--- a/cluster/apps/agentmemory/agentmemory/app/restart-cronjob.yaml
+++ b/cluster/apps/agentmemory/agentmemory/app/restart-cronjob.yaml
@@ -45,7 +45,7 @@ metadata:
   name: agentmemory-restart
   namespace: agentmemory
 spec:
-  schedule: "0 4 * * *"
+  schedule: "0 4,16 * * *"
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid

--- a/cluster/apps/agentmemory/agentmemory/app/values.yaml
+++ b/cluster/apps/agentmemory/agentmemory/app/values.yaml
@@ -36,7 +36,7 @@ controllers:
             cpu: 10m
             memory: 256Mi
           limits:
-            memory: 1280Mi
+            memory: 1536Mi
         probes:
           liveness:
             enabled: true

--- a/cluster/apps/agentmemory/agentmemory/app/vpa.yaml
+++ b/cluster/apps/agentmemory/agentmemory/app/vpa.yaml
@@ -18,7 +18,7 @@ spec:
           cpu: 1m
           memory: 1Mi
         maxAllowed:
-          memory: 1280Mi
+          memory: 1536Mi
       - containerName: console
         minAllowed:
           cpu: 1m


### PR DESCRIPTION
## Summary
- Bump engine memory limit 1280Mi → 1536Mi (VPA uncapped target 1.75GiB, plateau at ~1.1GiB)
- Update VPA maxAllowed to match
- Restart CronJob from daily to every 12h as safety net

## Linked Issue
Closes #1550

## Changes
- `values.yaml`: engine memory limit 1280Mi → 1536Mi
- `vpa.yaml`: maxAllowed 1280Mi → 1536Mi
- `restart-cronjob.yaml`: schedule `0 4 * * *` → `0 4,16 * * *`

## Root Cause
10,691 raw observations in BM25 index load into RAM on startup (~1.1GiB baseline). Upstream `mem::evict` has a 10k observation cap but no timer/env toggle — never runs. Filed upstream issue request.

## Testing
- VPA recommendations confirmed 1.75GiB uncapped target
- Memory profile from VictoriaMetrics shows 1.1GiB plateau with slow creep
- qa-validator passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)