### PR TITLE
fix(llm-guard-adapter): handle array-type content in OpenAI messages

### DIFF
--- a/cmd/llm-guard-adapter/main.go
+++ b/cmd/llm-guard-adapter/main.go
@@ -93,8 +93,41 @@ type litellmRequest struct {
 }
 
 type structuredMsg struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role    string         `json:"role"`
+	Content messageContent `json:"content"`
+}
+
+type messageContent struct {
+	Text string
+}
+
+func (m *messageContent) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err == nil {
+		m.Text = s
+		return nil
+	}
+
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(data, &parts); err != nil {
+		return fmt.Errorf("content must be string or array of parts: %w", err)
+	}
+
+	var texts []string
+	for _, p := range parts {
+		if p.Type == "text" && p.Text != "" {
+			texts = append(texts, p.Text)
+		}
+	}
+	m.Text = strings.Join(texts, "\n")
+	return nil
+}
+
+func (m messageContent) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Text)
 }
 
 type litellmResponse struct {
@@ -176,7 +209,7 @@ func (a *adapter) extractPrompt(req litellmRequest) string {
 	var parts []string
 	for _, msg := range req.StructuredMessages {
 		if msg.Role == "user" {
-			parts = append(parts, msg.Content)
+			parts = append(parts, msg.Content.Text)
 		}
 	}
 	return strings.Join(parts, "\n")

--- a/cmd/llm-guard-adapter/main_test.go
+++ b/cmd/llm-guard-adapter/main_test.go
@@ -120,13 +120,82 @@ func TestExtractPromptFromStructuredMessages(t *testing.T) {
 	a := &adapter{logger: slog.New(slog.NewJSONHandler(io.Discard, nil))}
 	req := litellmRequest{
 		StructuredMessages: []structuredMsg{
-			{Role: "system", Content: "You are helpful"},
-			{Role: "user", Content: "Hello there"},
-			{Role: "user", Content: "How are you"},
+			{Role: "system", Content: messageContent{Text: "You are helpful"}},
+			{Role: "user", Content: messageContent{Text: "Hello there"}},
+			{Role: "user", Content: messageContent{Text: "How are you"}},
 		},
 	}
 	got := a.extractPrompt(req)
 	if got != "Hello there\nHow are you" {
 		t.Fatalf("expected user messages joined, got %q", got)
+	}
+}
+
+func TestUnmarshalContentString(t *testing.T) {
+	input := `{"role":"user","content":"hello world"}`
+	var msg structuredMsg
+	if err := json.Unmarshal([]byte(input), &msg); err != nil {
+		t.Fatalf("unmarshal string content: %v", err)
+	}
+	if msg.Content.Text != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", msg.Content.Text)
+	}
+}
+
+func TestUnmarshalContentArray(t *testing.T) {
+	input := `{"role":"user","content":[{"type":"text","text":"describe this image"},{"type":"image_url","image_url":{"url":"https://example.com/img.png"}}]}`
+	var msg structuredMsg
+	if err := json.Unmarshal([]byte(input), &msg); err != nil {
+		t.Fatalf("unmarshal array content: %v", err)
+	}
+	if msg.Content.Text != "describe this image" {
+		t.Fatalf("expected 'describe this image', got %q", msg.Content.Text)
+	}
+}
+
+func TestUnmarshalContentArrayMultipleTexts(t *testing.T) {
+	input := `{"role":"user","content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}`
+	var msg structuredMsg
+	if err := json.Unmarshal([]byte(input), &msg); err != nil {
+		t.Fatalf("unmarshal multi-text content: %v", err)
+	}
+	if msg.Content.Text != "first\nsecond" {
+		t.Fatalf("expected 'first\\nsecond', got %q", msg.Content.Text)
+	}
+}
+
+func TestAdapterHandlesArrayContent(t *testing.T) {
+	guardServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req llmGuardRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Prompt != "describe this image" {
+			t.Errorf("expected prompt 'describe this image', got %q", req.Prompt)
+		}
+		json.NewEncoder(w).Encode(llmGuardResponse{
+			SanitizedPrompt: req.Prompt,
+			IsValid:         true,
+			Scanners:        map[string]float64{"PromptInjection": -1},
+		})
+	}))
+	defer guardServer.Close()
+
+	a := &adapter{
+		client:      guardServer.Client(),
+		llmGuardURL: guardServer.URL,
+		threshold:   0.5,
+		logger:      slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
+
+	body := `{"structured_messages":[{"role":"user","content":[{"type":"text","text":"describe this image"},{"type":"image_url","image_url":{"url":"https://example.com/img.png"}}]}],"input_type":"request","litellm_call_id":"test-array"}`
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	a.ServeHTTP(w, req)
+
+	var resp litellmResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp.Action != "NONE" {
+		t.Fatalf("expected NONE, got %q (reason: %s)", resp.Action, resp.BlockedReason)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix JSON parse failures when `content` field in `structured_messages` is an array (OpenAI multi-modal format) instead of a string
- Added `messageContent` type with custom `UnmarshalJSON` to handle both `string` and `[{type, text}]` formats
- Extracts text parts from arrays, skips non-text parts (image_url, etc.)
- **Security impact**: previously, multi-modal requests bypassed guardrail scanning entirely due to fail-open on parse error

## Linked Issue
Closes #1559

## Changes
- `cmd/llm-guard-adapter/main.go`: Added `messageContent` type with custom JSON marshal/unmarshal, updated `extractPrompt` to use `.Content.Text`
- `cmd/llm-guard-adapter/main_test.go`: Added 4 tests — string unmarshal, array unmarshal, multi-text array, full adapter integration with array content

## Testing
- All 9 tests pass (including 4 new) with `-race` flag
- MegaLinter clean
- Verified against LiteLLM upstream docs (Context7) — format matches their `structured_messages` spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)