### PR TITLE
chore(n8n): update n8n and task runner to 2.36.7 stable

### DIFF
--- a/cluster/apps/n8n-system/n8n/app/release.yaml
+++ b/cluster/apps/n8n-system/n8n/app/release.yaml
@@ -19,8 +19,8 @@ spec:
         images:
           - name: n8nio/runners
             # renovate: datasource=docker depName=n8nio/runners
-            newTag: "2.35.7"
-            digest: sha256:0fdd4a56f501881f2f3c567f798c86a2b31a6c8cd629e8f91b710321f6abd823
+            newTag: "2.36.7"
+            digest: sha256:7d4463a5bd2da20dcaab904a761196ffbc0699d46f5f812c100526e4956f1de1
         patches:
           - target:
               kind: Deployment

--- a/cluster/apps/n8n-system/n8n/app/values.yaml
+++ b/cluster/apps/n8n-system/n8n/app/values.yaml
@@ -6,7 +6,7 @@
 image:
   repository: n8nio/n8n
   pullPolicy: IfNotPresent
-  tag: "2.35.7@sha256:166d7e3ca384afdffe75394bf00046c299d84a4bf17b19b35d6cf7773af0a147"
+  tag: "2.36.7@sha256:14c4285bc3034dc5b51034aea393711d27053588e460722bce523453a626f23c"
 main:
   config:
     queue:


### PR DESCRIPTION
## Summary

Update n8n and its task-runner sidecar from 2.35.7 to 2.36.7, the current upstream stable release, with each tag paired to its matching registry digest.

This replaces Renovate's #2612 (2.36.1, autoclosed) and #2613 (2.36.2). Both proposed beta-channel builds — upstream marks 2.36.0 through 2.36.5 as pre-releases. 2.36.6 is the first stable 2.36.x, and 2.36.7 is the current `latest`; both `n8nio/n8n:stable` and `n8nio/runners:stable` resolve to the 2.36.7 digests.

Those PRs also bumped the runner `newTag` while leaving the adjacent `digest:` field alone. The Kustomize image transformer emits `name:tag@digest` and the runtime resolves by digest, so merging them would have left the sidecar running 2.35.7 content under a 2.36.7 label. Both fields move together here.

## Linked Issue

Ref #2614
Ref #2615

## Changes

- `values.yaml`: `n8nio/n8n` 2.35.7 → 2.36.7 with digest `sha256:14c4285b…`
- `release.yaml`: `n8nio/runners` `newTag` 2.35.7 → 2.36.7 and `digest` → `sha256:7d4463a5…`

## Testing

Validated before commit:

- Both digests confirmed against the Docker Hub registry API; each is an OCI index covering `linux/amd64` and `linux/arm64`.
- Chart 2.1.0 rendered with `helm template` using the repo values, then the actual `postRenderers.kustomize` block from `release.yaml` applied on top. The `n8n-worker` → `task-runner` container resolves to the 2.36.7 digest, and `kubectl apply --dry-run=client` is clean on the result.
- MegaLinter: 13 linters, no errors or warnings. gitleaks, secretlint and trivy clean.
- `2.35.7` appears nowhere else in the repo. `vpa.yaml` needs no change — limits are unchanged and the `task-runner` policy still applies.
- Release notes 2.36.0 through 2.36.7 reviewed: no breaking changes to task runners, external hooks, queue/Redis, metrics or OTel. The only workflow-level deprecation is `Array.merge` → `Array.mergeIntoObject`.

## Post-merge verification

There are no database migrations between 2.35.7 and 2.36.7, so rollback is clean.

Two behavioural changes in 2.36.x warrant a check after deploy:

1. `packages/cli/src/server.ts` reorders middleware so `cookieParser()` now runs ahead of the Public API routers. The Authentik forward-auth hook splices itself in immediately after the `cookieParser` layer, so its effective scope widens to `/api/v1/*`. Confirm the main pod logs the hook installing, and that an SSO login round-trip succeeds — this integration has required reverts on two previous version bumps.
2. 2.36.x adds a session-cookie authentication strategy. Combined with the reorder above, a request to `/api/v1/*` carrying the forward-auth header for a pre-provisioned user can authenticate via the cookie the hook mints, where an API key was previously required. This stays gated by the forward-auth middleware on the ingress route, but it is an authorization-surface change worth a conscious decision. If unwanted, the hook can early-return for paths under `/api/`.
