### PR TITLE
chore(renovate): follow the n8n stable channel tag

### DIFF
--- a/.github/renovate-overrides.json5
+++ b/.github/renovate-overrides.json5
@@ -13,14 +13,20 @@
       "enabled": false
     },
     {
-      "description": "Use semver for n8n docker images to ignore pre-release tags (beta, nightly, etc)",
+      // n8n ships beta builds as plain semver docker tags with no pre-release
+      // suffix, so ignoreUnstable has nothing to key off and `versioning: semver`
+      // does not filter them — only the GitHub Release prerelease flag marks them,
+      // and the docker datasource never sees it. Follow the stable channel tag
+      // instead. Note this bypasses normal versioning logic entirely: if upstream
+      // renames or drops the `stable` tag, updates stop silently.
+      "description": "Follow the n8n stable channel tag, since beta builds are indistinguishable by version string alone",
       "matchPackageNames": [
         "n8nio/**"
       ],
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "semver"
+      "followTag": "stable"
     },
     {
       "description": "Coder: ignore pre-release versions (default versioning delay handles maturity)",


### PR DESCRIPTION
## Summary

Replaces the ineffective pre-release filter for n8n images with `followTag: "stable"`.

The existing rule uses `versioning: semver` for `n8nio/**`, commented "ignore pre-release tags (beta, nightly, etc)". That cannot work. n8n publishes beta builds as plain semver Docker tags with no pre-release suffix, so `ignoreUnstable` has nothing to key off — only the GitHub Release `prerelease` flag distinguishes them, and the Docker datasource never sees it. Raising `minimumReleaseAge` would not help either: the beta that prompted this had already cleared the stability window.

Upstream marks 2.36.0 through 2.36.5 as pre-releases. Renovate proposed 2.36.1 (#2612, autoclosed) and then 2.36.2 (#2613, closed as superseded), both beta.

## Linked Issue

Ref #2615

Addresses defect 2 of two. Defect 1 — the unmanaged Kustomize `digest` field — is fixed upstream in anthony-spruyt/repo-operator#342 and will need a small follow-up here to move the annotation once that merges.

## Changes

- `n8nio/**` Docker updates now follow the `stable` channel tag instead of relying on semver versioning to filter betas.

## Testing

- `renovate-config-validator` passes: `Config validated successfully against 1 file(s)`.
- Confirmed against the Docker Hub registry API that the `stable` tag exists and is maintained for both images, and currently resolves to the 2.36.7 digests:
  - `n8nio/n8n:stable` → `sha256:14c4285b…`, identical to `n8nio/n8n:2.36.7`
  - `n8nio/runners:stable` → `sha256:7d4463a5…`, identical to `n8nio/runners:2.36.7`

## Caveat

`followTag` bypasses Renovate's normal versioning logic and syncs strictly to whatever the named tag points at. If upstream renames or abandons the `stable` tag, updates stop silently rather than erroring. This is noted inline in the config, and is worth a periodic check that n8n PRs are still arriving.
