### PR TITLE
chore(renovate): require dashboard approval for n8n docker images

### DIFF
--- a/.github/renovate-overrides.json5
+++ b/.github/renovate-overrides.json5
@@ -13,14 +13,21 @@
       "enabled": false
     },
     {
-      "description": "Use semver for n8n docker images to ignore pre-release tags (beta, nightly, etc)",
+      // n8n ships beta builds as plain semver docker tags with no pre-release
+      // suffix, so no versioning option can filter them — only the GitHub Release
+      // prerelease flag marks a build as beta, and the docker datasource never
+      // sees it. followTag does not help either: it reads ReleaseResult.tags,
+      // which the docker datasource does not populate, so it would return no
+      // updates at all. Gate these behind the dependency dashboard instead, so a
+      // beta surfaces for review rather than opening a PR on its own.
+      "description": "Require dashboard approval for n8n docker images, since beta builds are indistinguishable by version string alone",
       "matchPackageNames": [
         "n8nio/**"
       ],
       "matchDatasources": [
         "docker"
       ],
-      "versioning": "semver"
+      "dependencyDashboardApproval": true
     },
     {
       "description": "Coder: ignore pre-release versions (default versioning delay handles maturity)",


### PR DESCRIPTION
## Summary

Replaces the ineffective pre-release filter for n8n images with a dependency dashboard approval gate.

The existing rule uses `versioning: semver` for `n8nio/**`, commented "ignore pre-release tags (beta, nightly, etc)". It cannot work. n8n publishes beta builds as plain semver Docker tags with no pre-release suffix, so no versioning option can filter them — only the GitHub Release `prerelease` flag marks a build as beta, and the Docker datasource never sees it. Upstream marks 2.36.0 through 2.36.5 as pre-releases, and Renovate duly proposed 2.36.1 (#2612) and then 2.36.2 (#2613).

## Linked Issue

Ref #2615

Defect 1 of that issue — the unmanaged Kustomize `digest` field — is fixed by anthony-spruyt/repo-operator#342, now merged. This PR addresses defect 2.

## Why not `followTag: "stable"`

That was the first attempt (#2617, closed). `followTag` reads `ReleaseResult.tags`, a map only the npm, deno and `custom` datasources populate. The Docker datasource never does, so the lookup returns early with **no updates at all** — it would have silently halted every n8n update rather than filtering betas, surfacing only as a Dependency Dashboard warning.

The `stable` tag itself does exist on Docker Hub for both images and resolves to the 2.36.7 digests. It is simply not reachable through `followTag`.

## Why not a custom datasource

Renovate's `custom` datasource can emit `isStable` per release, which would give real filtering. But its `getDigest` returns `null`, so digests can only come from the upstream endpoint, and no single endpoint carries both the prerelease flag and the image digest — GitHub releases has stability but no digest, Docker Hub has digests but no stability. A custom datasource gets one fetch, so the two cannot be joined.

Stability filtering and Renovate-managed digests are therefore mutually exclusive for this dependency. Since repo-operator#342 exists specifically to get the runner digest managed, giving that up for n8n would undo the fix for the app that motivated it.

## Changes

- `n8nio/**` Docker updates now require approval from the Dependency Dashboard before a PR is opened.

## Trade-off

Betas are not filtered — they surface on the dashboard instead of opening PRs unprompted. This keeps digest management intact and keeps version numbers and changelogs visible for review, which matters here: the Authentik forward-auth hook has forced two reverts on previous n8n version bumps, so release notes are load-bearing during review.

## Testing

- `renovate-config-validator` passes: `Config validated successfully against 1 file(s)`.
- Confirmed `dependencyDashboardApproval` carries no `parents` restriction or `globalOnly` flag in Renovate's option definitions, so it is valid inside `packageRules`.
