### PR TITLE
chore(n8n): move renovate annotation above the images list item

### DIFF
--- a/cluster/apps/n8n-system/n8n/app/release.yaml
+++ b/cluster/apps/n8n-system/n8n/app/release.yaml
@@ -17,8 +17,8 @@ spec:
   postRenderers:
     - kustomize:
         images:
+          # renovate: datasource=docker depName=n8nio/runners
           - name: n8nio/runners
-            # renovate: datasource=docker depName=n8nio/runners
             newTag: "2.36.7"
             digest: sha256:7d4463a5bd2da20dcaab904a761196ffbc0699d46f5f812c100526e4956f1de1
         patches:


### PR DESCRIPTION
## Summary

Moves the `# renovate:` annotation in the n8n HelmRelease above the `- name:` line so Renovate keeps the runner `digest` in sync with `newTag`.

anthony-spruyt/repo-operator#342 (merged) added managers that capture both fields, but they anchor on the annotation sitting above the list item:

```yaml
images:
  # renovate: datasource=docker depName=n8nio/runners
  - name: n8nio/runners
    newTag: "2.36.7"
    digest: sha256:...
```

That placement is load-bearing rather than stylistic. The generic "Annotated YAML field" managers require a `key: value` line directly beneath the comment, and `- name:` is not one — the line begins with `-`, which `\w+` cannot match. So with the annotation there, the generic managers are structurally unable to claim the entry and leave the digest unmanaged. Renovate compiles custom manager regexes with RE2, which has no lookahead, so anchoring on the list item is the only way to break that overlap.

## Linked Issue

Closes #2615

Completes the last checklist item. Defect 1 was fixed upstream in repo-operator#342; defect 2 by #2619.

## Changes

- `cluster/apps/n8n-system/n8n/app/release.yaml`: annotation moved one line up, above `- name: n8nio/runners`.

## Testing

- Fetched the **merged** preset from `repo-operator@main` and matched all 12 managers against this exact file. Exactly one matches — `Annotated kustomize images entry (datasource first)` — capturing `currentValue: 2.36.7` and `currentDigest: sha256:7d4463a5…`. No duplicate extraction from the generic managers.
- Parsed the file before and after with `yq`; the JSON structures are identical, so the rendered HelmRelease is unchanged and this is a no-op for the cluster.

## Validation note

qa-validator was not run. This is a comment-only move with a proven-identical parse, which meets the trivial-scope fast path. The meaningful risk here is Renovate matching behaviour rather than manifest rendering, and that was verified directly against the merged upstream preset — a stronger check than a lint pass. cluster-validator is likewise unnecessary since the rendered output does not change, and one is already running for #2616.
