### PR TITLE
fix(n8n): stop task runner thrashing and spurious webhook hook error

### DIFF
--- a/cluster/apps/n8n-system/n8n/app/hooks-configmap.yaml
+++ b/cluster/apps/n8n-system/n8n/app/hooks-configmap.yaml
@@ -31,6 +31,13 @@ data:
         ready: [
           async function ({ app }, config) {
             try {
+              // Only the main process builds the UI auth stack to splice into.
+              const role = process.argv.slice(2).find((a) => a === 'webhook' || a === 'worker');
+              if (role) {
+                log(`not applicable for the $${role} process - skipping`);
+                return;
+              }
+
               const stack = app.router?.stack ?? app._router?.stack;
               if (!stack) {
                 logError('SSO disabled - no Express router stack', new Error('app.router missing'));

--- a/cluster/apps/n8n-system/n8n/app/release.yaml
+++ b/cluster/apps/n8n-system/n8n/app/release.yaml
@@ -43,6 +43,9 @@ spec:
                         env:
                           - name: N8N_RUNNERS_TASK_BROKER_URI
                             value: http://localhost:5679
+                          # Default 15s is shorter than the gap between tasks
+                          - name: N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT
+                            value: "300"
                           - name: N8N_RUNNERS_AUTH_TOKEN
                             valueFrom:
                               secretKeyRef:

--- a/cluster/apps/n8n-system/n8n/app/values.yaml
+++ b/cluster/apps/n8n-system/n8n/app/values.yaml
@@ -192,6 +192,9 @@ main:
       emptyDir: {}
   deploymentAnnotations: &deploymentAnnotations
     secret.reloader.stakater.com/reload: "n8n-cnpg-cluster-app,n8n-secrets,n8n-runner-secrets"
+    # Static name + subPath mount, so pods never pick up edits without a roll.
+    # Excludes n8n-prompts: directory mount, kubelet updates it live (see #1131)
+    configmap.reloader.stakater.com/reload: "n8n-hooks"
   securityContext: &securityContext
     capabilities:
       drop:


### PR DESCRIPTION
## Summary

Fixes two runtime defects found during the 2.36.7 validation and set aside as pre-existing.

**JavaScript task runner thrashing.** `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` defaults to 15s, shorter than this workload's ~20-40s gap between JavaScript tasks, so the runner shut down between nearly every pair. Each shutdown left a window with no JavaScript offer registered, and tasks arriving in it failed:

```
No matching task offer for request "LBntAawayhvFa_AQJlLr6" (type "javascript"). Available offer types: [python]
```

Daily for at least 14 days at 5-233 per day, still occurring on 2.36.7.

**Spurious forward-auth error on the webhook.** `EXTERNAL_HOOK_FILES` is shared across all three components, but only main builds the UI auth stack, so the webhook logged `[forward-auth] SSO disabled - cookieParser layer not found` on every boot. That devalues the identical message on main, where it means SSO is actually down — an integration that has already forced two reverts (`1bf76ad1`, `17e3d9a3`).

## Linked Issue

Closes #2621

## Changes

- `release.yaml`: `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT: "300"` on the task-runner sidecar.
- `hooks-configmap.yaml`: hook returns early on the webhook and worker processes.
- `values.yaml`: `configmap.reloader.stakater.com/reload: "n8n-hooks"` on the shared `deploymentAnnotations` anchor.

## Why the reloader annotation is needed

Without it this PR would merge and do nothing. `n8n-hooks` is a plain resource with a static name, so editing it changes no field on the Deployment; the chart's `checksum/config` hashes only `.Values`; and the `subPath: hooks.js` mount never updates in place. `n8n-worker` would roll, but `n8n-webhook` — the component this targets — would not.

Adding the annotation also mutates `.Values`, so every `checksum/config` changes and all three deployments roll on this commit. Verified both mechanisms: the rendered checksums differ from HEAD, and the `n8n-values` generator hash moves `ff8fh4gm8m` → `bb9c44fttg` while the old hash is what the live HelmRelease references, so Flux forces the upgrade regardless.

`n8n-prompts` is deliberately excluded. It has a static name too, but it is a directory mount with no `subPath`, so it gets the `..data` atomic-swap projection and kubelet propagates edits live. Watching it would regress #1131 and buy pure downtime — all three deployments are `Recreate` with a single replica, and `app/prompts/` sees ~46 commits a year.

## Testing

qa-validator, two rounds. The first round blocked on the missing rollout mechanism, the second on the `n8n-prompts` inclusion; both are resolved above.

- `N8N_RUNNERS_AUTO_SHUTDOWN_TIMEOUT` verified against `n8n-io/task-runner-launcher` source — name, seconds unit, default 15, and it is launcher `BaseConfig` so it belongs on the sidecar, not the n8n container. Present in the 2.36.7 image's `n8n-task-runners.json` `allowed-env` for both runner types, so it propagates without the legacy deprecation warning.
- `300` sits well above the observed task gap. Peak `task-runner` working set over 7d is 147 MiB against the 512 Mi VPA cap. `0` was rejected: the process executes user-supplied Code node JavaScript and periodic recycling is worth keeping.
- Post-render against the pinned chart: the patch creates the `task-runner` container with all three env entries, the `secretKeyRef` intact, and the image resolving to the 2.36.7 digest.
- `hooks.js` unescaped with real `flux envsubst`, `node --check` passes. argv verified on the live pods — main is `node /usr/local/bin/n8n`, webhook adds `webhook`, worker adds `worker --concurrency=10` — so the early return provably cannot fire on main.
- Reloader `v1.4.21` accepts a comma-separated list, runs with no namespace or label filtering, and its ClusterRole has `update`/`patch` on `apps/deployments` bound cluster-wide.
- MegaLinter 13 linters, 0 errors. gitleaks clean. `kustomize build` and dry-runs clean.

## Known limitation

`300` mitigates the offer race rather than eliminating it — a task can still land in the gap following a genuine 5-minute idle. Only `0` closes it fully, at the cost of never recycling the runner process.
