### PR TITLE
chore(agent-queue-worker): replace deprecated prom-client with @prometheus-io/client

### DIFF
--- a/ts/agent-queue-worker/package-lock.json
+++ b/ts/agent-queue-worker/package-lock.json
@@ -8,9 +8,9 @@
       "name": "agent-queue-worker",
       "version": "3.0.0",
       "dependencies": {
+        "@prometheus-io/client": "^0.16.0",
         "bullmq": "^5.52.0",
         "ioredis": "5.11.1",
-        "prom-client": "^15.1.3",
         "zod": "^4.0.0"
       },
       "devDependencies": {
@@ -831,6 +831,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@prometheus-io/client": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@prometheus-io/client/-/client-0.16.0.tgz",
+      "integrity": "sha512-efsu46oP33Lc9x2JQc4V/2wB0aQmhdQst30M5a8oYafl1XInCyvAIdBCiWygFSgWHNWBYIwyTCAFDuUoOZ8LOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^22 || ^24 || >=26"
       }
     },
     "node_modules/@rolldown/binding-android-arm-eabi": {
@@ -2075,19 +2088,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/prom-client": {
-      "version": "15.1.3",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
-      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.4.0",
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/redis-errors": {

--- a/ts/agent-queue-worker/package.json
+++ b/ts/agent-queue-worker/package.json
@@ -17,9 +17,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@prometheus-io/client": "^0.16.0",
     "bullmq": "^5.52.0",
     "ioredis": "5.11.1",
-    "prom-client": "^15.1.3",
     "zod": "^4.0.0"
   },
   "overrides": {

--- a/ts/agent-queue-worker/src/job/identity.test.ts
+++ b/ts/agent-queue-worker/src/job/identity.test.ts
@@ -1,4 +1,4 @@
-import type { Histogram } from "prom-client";
+import type { Histogram } from "@prometheus-io/client";
 import { describe, expect, it, vi } from "vitest";
 import type { Config } from "../config.js";
 import { createDefaultRegistry } from "../roles/registry.js";

--- a/ts/agent-queue-worker/src/metrics.ts
+++ b/ts/agent-queue-worker/src/metrics.ts
@@ -1,4 +1,4 @@
-import { Counter, Gauge, Histogram, Registry } from "prom-client";
+import { Counter, Gauge, Histogram, Registry } from "@prometheus-io/client";
 
 export const registry = new Registry();
 registry.setDefaultLabels({ service: "agent-queue-worker" });

--- a/ts/agent-queue-worker/src/roles/registry.ts
+++ b/ts/agent-queue-worker/src/roles/registry.ts
@@ -1,4 +1,4 @@
-import type { Histogram } from "prom-client";
+import type { Histogram } from "@prometheus-io/client";
 import type { Config } from "../config.js";
 import { executeIssueRole } from "./execute-issue-role.js";
 import { createRenovateRole } from "./renovate-role.js";

--- a/ts/agent-queue-worker/src/roles/roles.test.ts
+++ b/ts/agent-queue-worker/src/roles/roles.test.ts
@@ -1,4 +1,4 @@
-import type { Histogram } from "prom-client";
+import type { Histogram } from "@prometheus-io/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "../config.js";
 import type { AgentJob } from "../job/schema.js";

--- a/ts/agent-queue-worker/src/roles/sre-alert-role.ts
+++ b/ts/agent-queue-worker/src/roles/sre-alert-role.ts
@@ -1,5 +1,5 @@
+import type { Histogram } from "@prometheus-io/client";
 import type { Redis } from "ioredis";
-import type { Histogram } from "prom-client";
 import type { Config } from "../config.js";
 import type { AgentJob } from "../job/schema.js";
 import type { DuplicateAction, JobState, RoleDefinition } from "./types.js";


### PR DESCRIPTION
## Summary

`prom-client` is deprecated on npm: `prom-client has been replaced by @prometheus-io/client`. The library moved to the Prometheus org (`prometheus/client_js`) and publishes under the new scoped name starting at v0.16.0 (2026-08-24). Renovate flags the deprecation on the dependency dashboard but cannot generate a replacement PR for it.

## Linked Issue

Closes #2627

## Changes

- Replace `prom-client@^15.1.3` with `@prometheus-io/client@^0.16.0` in `ts/agent-queue-worker/package.json` and refresh the lockfile
- Update the five import sites (`src/metrics.ts`, `src/roles/registry.ts`, `src/roles/sre-alert-role.ts`, `src/roles/roles.test.ts`, `src/job/identity.test.ts`)

## Compatibility notes

Same codebase, renamed package. The used API surface is `Counter`, `Gauge`, `Histogram`, and `Registry` only, so none of the 0.16.0 breaking changes apply:

- No `AggregatorRegistry` usage (renamed to `ClusterRegistry`)
- No `MetricType` value references (numeric enum became a string union)
- No metric subclassing (internal `hashMap` became `LabelMap`)
- No counter exemplars (now report value rather than delta)
- No cluster or worker-thread integration (IPC message prefixes were rebranded)

Metric names and exposition format are unchanged, so no dashboard, recording rule, or alert rule changes are needed.

The engine range narrowed to `^22 || ^24 || >=26`. The package declares `node >=22` and the container image is `node:24-alpine`, so both satisfy it. Runtime dependencies (`@opentelemetry/api`, `tdigest`) are the same as before.

## Testing

- `npm run typecheck` — clean
- `npm test` — 309 tests across 11 files pass
- `npm run lint` — no new findings; the two remaining `noUnsafeOptionalChaining` errors in `src/roles/roles.test.ts` are pre-existing on `main` and unrelated to this change

Post-merge verification: confirm the worker's `/metrics` endpoint still exposes the `agent_*` series after the new image rolls out.
