### PR TITLE
chore(ci): run Node test suites in the release workflow

### DIFF
--- a/.github/workflows/_release-image.yaml
+++ b/.github/workflows/_release-image.yaml
@@ -185,10 +185,25 @@ jobs:
         uses: "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020" # v7
         with:
           node-version: "24"
+      - name: "Install dependencies (Node)"
+        if: "inputs.language == 'node'"
+        working-directory: "${{ inputs.workdir }}"
+        run: npm ci --ignore-scripts
       - name: "Type check (Node)"
         if: "inputs.language == 'node'"
         working-directory: "${{ inputs.workdir }}"
-        run: npm ci --ignore-scripts && npx tsc --noEmit
+        run: npx tsc --noEmit
+      - name: "Run tests (Node)"
+        if: "inputs.language == 'node'"
+        working-directory: "${{ inputs.workdir }}"
+        env:
+          WORKDIR: "${{ inputs.workdir }}"
+        run: |
+          if node -e 'process.exit(require("./package.json").scripts?.test ? 0 : 1)'; then
+            npm test
+          else
+            echo "::notice::No test script in ${WORKDIR}/package.json, skipping tests"
+          fi
       - name: "Setup Go"
         if: "inputs.language == 'go'"
         uses: "actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e" # v7


### PR DESCRIPTION
## Summary

The shared release workflow never ran the Node test suites. For `language: node` the Test job did `npm ci --ignore-scripts && npx tsc --noEmit` and stopped, while the Go path ran `go test -race ./...`. The 309 vitest tests in `ts/agent-queue-worker` were absent from both the pull request gate and the release path — `ci.yaml` calls this same reusable workflow and differs only in the `push` input, so a single missing step blinded both.

Surfaced during the `prom-client` to `@prometheus-io/client` migration (#2627). Build and typecheck did cover the realistic failure modes for that swap, but a metric silently failing to record would have shipped green.

## Linked Issue

Closes #2638

## Changes

- Split `npm ci --ignore-scripts` out of the type check step so the test step reuses the installed tree
- Add a "Run tests (Node)" step that runs the package's `test` script

`ts/agent-queue-worker/bull-board` declares no `test` script, so a bare `npm test` would fail that build. The step probes for the script and emits a `::notice::` when absent rather than no-opping quietly — an invisible skip is the same failure mode this PR exists to close.

The Test job is already in `needs:` for `build-and-release`, so test failures now block the image build and the release for Node services.

## Testing

Validated by qa-validator (report on #2638):

- MegaLinter: actionlint 1.7.12 and yamllint 1.38.0 both clean, exit 0
- Probe verified on Node 24.16.0 (matching the pinned `node-version`): exit 0 in `ts/agent-queue-worker`, exit 1 in `bull-board`. `require` resolves under `node -e` regardless of `"type": "module"`, and an absent `scripts` key short-circuits instead of throwing
- Step split replayed in a clean tree: `npm ci --ignore-scripts` then `npx tsc --noEmit` then `npm test` → 11 files, 309 passed. `--ignore-scripts` does not break vitest, since esbuild resolves its platform binary from the optional dep at runtime rather than via postinstall
- Shell safety confirmed under `bash -e` and `bash -eo pipefail`: an `if`-condition command is exempt from `set -e`, and a genuinely failing test script still exits the step non-zero
- Go path untouched; no new inputs, so none of the 10 call sites change

Note: `.github/**` matches no path filter in `ci.yaml`, so the Node jobs are skipped on this PR and the new step will not be exercised here. It takes effect on the next change under `ts/`.
