### PR TITLE
chore(ci): fail the release when registry and git tags drift

### DIFF
--- a/.github/workflows/_release-image.yaml
+++ b/.github/workflows/_release-image.yaml
@@ -160,14 +160,17 @@ jobs:
             exit 0
           fi
 
-          # Check if image tag already exists in registry
+          # The version was derived from git tags, so the image cannot legitimately
+          # exist yet. If it does, a previous run pushed the image but never created
+          # the tag, and every subsequent release would silently resolve to this same
+          # version and skip. Fail instead of accumulating unreleased commits.
           if docker manifest inspect "$IMAGE_REF" > /dev/null 2>&1; then
-            echo "::warning::Image $IMAGE_REF already exists in registry, skipping build"
-            echo "should-build=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Image $IMAGE_REF not found in registry, will build"
-            echo "should-build=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Registry and git tags have drifted: $IMAGE_REF already exists, but ${TAG_PREFIX}${VERSION} does not. A previous run pushed the image without creating the tag. Backfill the tag at the commit the image was built from, then re-run: git tag ${TAG_PREFIX}${VERSION} <commit> && git push origin ${TAG_PREFIX}${VERSION}"
+            exit 1
           fi
+
+          echo "::notice::Image $IMAGE_REF not found in registry, will build"
+          echo "should-build=true" >> "$GITHUB_OUTPUT"
   test:
     name: "Test"
     needs: "resolve-version"


### PR DESCRIPTION
## Summary

The release pipeline for both Node services had been silently skipping builds since 2026-07-25 — 19 unreleased commits for `agent-queue-worker`, 6 for `bull-board`, including the `prom-client` migration (#2627), which merged cleanly and produced no image.

`resolve-version` derives the next version by incrementing the newest git tag; `check-release` then skipped the build if that version already existed in GHCR. That skip cannot tell "already released" apart from "the registry is ahead of git". Images `agent-queue-worker:3.3.46` and `bull-board:0.2.30` were published and deployed while their git tags were never created, so every merge afterwards resolved to the published version, hit the skip, and reported success while building nothing.

## Linked Issue

Closes #2641

## Changes

`check-release` now fails with the backfill command instead of skipping:

```
::error::Registry and git tags have drifted: <image> already exists, but <tag> does not.
A previous run pushed the image without creating the tag. Backfill the tag at the commit
the image was built from, then re-run: git tag <tag> <commit> && git push origin <tag>
```

Since the version comes from the git tags, an existing image is always evidence of a missing tag rather than a legitimate state.

Done outside this diff: tags `agent-queue-worker/v3.3.46` and `bull-board/v0.2.30` were created at `c4efe510` — the newest commit touching each service before Renovate bumped the deployed image tags on 2026-07-26 — and pushed. Both services now resolve to unpublished versions (3.3.47 and 0.2.31).

## Testing

Validated by qa-validator (report on #2641):

- `task dev-env:lint` exit 0 — actionlint over all 12 workflow files including shellcheck of the `run:` block, yamllint over 954 files, 0 errors
- Step body executed under `set -e` with the registry probe stubbed both ways: not-found → rc 0 with `should-build=true`; found → rc 1 with nothing written. `bash -e` does not abort on a command failing as an `if` condition
- Error message re-parsed with `yq` and inspected with `cat -A` — survives as one physical line; the whole string is double-quoted, so `&&` and `<commit>` stay literal
- Re-run safety confirmed via the `has-changes` gate rather than this check: a successful run tags its own `github.sha`, so `git log <tag>..HEAD -- <workdir>/` is empty on re-run and `check-release` never executes
- Dispatch-vs-push serialisation confirmed: in a reusable workflow the `github` context is the caller's, so both yield `refs/heads/main`, the same concurrency group, and `cancel-in-progress: false`

**Blast radius is push-to-main only.** `ci.yaml` passes `push: "${{ github.event_name == 'push' }}"`, so on a pull request the step returns at the dry-run branch before touching the registry. No PR is blocked and no required check changes.

## Known limitations

- A `workflow_dispatch` from a non-main ref gets a different concurrency group and can hit the window between "Push image to GHCR" and "Create git tag", producing a false-positive drift error. Pre-existing race; the previous code silently skipped in that same window, which was worse.
- The root cause is untouched — push-then-tag is still non-atomic, so drift can still be created; this only makes it loud. Moving tag creation ahead of the attestation step would shrink the window, and is worth a follow-up.
