### PR TITLE
ci(mcp-header-proxy): document release-please workflow

### DIFF
--- a/cmd/mcp-header-proxy/README.md
+++ b/cmd/mcp-header-proxy/README.md
@@ -1,0 +1,20 @@
+# mcp-header-proxy
+
+Reverse proxy that forwards MCP headers from an HTTP request into the JSON-RPC body before passing it upstream. Deployed as a sidecar alongside n8n, whose MCP client trigger reads the values from the body rather than the headers.
+
+Streaming responses are flushed immediately (`FlushInterval: -1`) so SSE streams are not buffered, and the write deadline is disabled for the same reason.
+
+## Configuration
+
+| Variable       | Default                 | Purpose                         |
+| -------------- | ----------------------- | ------------------------------- |
+| `LISTEN_ADDR`  | `:8080`                 | Address the proxy binds to      |
+| `UPSTREAM_URL` | `http://localhost:5678` | Upstream the request is sent to |
+
+`GET /healthz` returns `ok` and is used for probes.
+
+## Releases
+
+Versioning is managed by release-please. A push to `main` that touches this directory updates a release pull request; merging it creates the tag and a draft release, which triggers the image build. The release is published once the image has been pushed, so a published release always has an image behind it.
+
+Commit types drive the version: `feat` bumps the minor, `feat!` or a `BREAKING CHANGE` footer bumps the major, and anything else bumps the patch. A `Release-As: X.Y.Z` footer overrides the computed version.


### PR DESCRIPTION
## Summary

Adds a README for `mcp-header-proxy` covering what the proxy does, its two configuration variables, and how releases work under release-please.

It also serves as the first real commit under `cmd/mcp-header-proxy/**` since the pilot landed (#2652), so it exercises the full release path end to end: version bump, tag creation, draft release, image build, digest append, and publish.

Expected result is a patch bump to 0.0.9 — `ci` carries no special meaning to the versioning strategy and falls through to the patch default.

## Linked Issue

Ref #2644

## Testing

The release path is what this is testing. After merge, expect in order: a release pull request from the release app, then on merging that, a tag and draft release, then the build workflow, then a published release carrying the image digest.