### PR TITLE
fix(ci): add a recovery path for tagged releases with no image

### DIFF
--- a/.github/workflows/rebuild-release.yaml
+++ b/.github/workflows/rebuild-release.yaml
@@ -1,0 +1,110 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
+
+name: "Rebuild Release"
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: "Service to rebuild"
+        required: true
+        type: "choice"
+        options:
+          - "shutdown-orchestrator"
+          - "kata-tap-qdisc-fix"
+          - "mcp-header-proxy"
+          - "agent-queue-worker"
+          - "bull-board"
+      version:
+        description: "Version to rebuild, without a leading v (e.g., 0.2.10)"
+        required: true
+        type: "string"
+concurrency:
+  group: "rebuild-${{ inputs.service }}-${{ inputs.version }}"
+  cancel-in-progress: false
+jobs:
+  resolve:
+    name: "Resolve"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: "write"
+    outputs:
+      workdir: "${{ steps.service.outputs.workdir }}"
+      language: "${{ steps.service.outputs.language }}"
+      tag: "${{ steps.service.outputs.tag }}"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d
+        with:
+          egress-policy: audit
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          fetch-depth: 0
+      - name: "Resolve service"
+        id: "service"
+        env:
+          SERVICE: "${{ inputs.service }}"
+          VERSION: "${{ inputs.version }}"
+        run: |
+          case "$SERVICE" in
+            shutdown-orchestrator) WORKDIR="cmd/shutdown-orchestrator"; LANGUAGE="go" ;;
+            kata-tap-qdisc-fix)    WORKDIR="cmd/kata-tap-qdisc-fix";    LANGUAGE="go" ;;
+            mcp-header-proxy)      WORKDIR="cmd/mcp-header-proxy";      LANGUAGE="go" ;;
+            agent-queue-worker)    WORKDIR="ts/agent-queue-worker";     LANGUAGE="node" ;;
+            bull-board)            WORKDIR="ts/agent-queue-worker/bull-board"; LANGUAGE="node" ;;
+            *) echo "::error::Unknown service $SERVICE"; exit 1 ;;
+          esac
+
+          TAG="${SERVICE}/v${VERSION}"
+          {
+            echo "workdir=$WORKDIR"
+            echo "language=$LANGUAGE"
+            echo "tag=$TAG"
+          } >> "$GITHUB_OUTPUT"
+      - name: "Verify the release is recoverable"
+        env:
+          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          TAG: "${{ steps.service.outputs.tag }}"
+          SERVICE: "${{ inputs.service }}"
+          VERSION: "${{ inputs.version }}"
+        run: |
+          if ! git rev-parse -q --verify "refs/tags/${TAG}" > /dev/null; then
+            echo "::error::Tag ${TAG} does not exist. This workflow rebuilds an existing release; it does not create one."
+            exit 1
+          fi
+
+          if ! DRAFT=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
+            echo "::error::No release found for ${TAG}."
+            exit 1
+          fi
+
+          if [ "$DRAFT" != "true" ]; then
+            echo "::error::Release ${TAG} is already published. Cut a new version instead."
+            exit 1
+          fi
+
+          NEWEST=$(gh release list --limit 200 --json tagName,isDraft \
+            --jq '.[] | select(.isDraft == false) | .tagName' \
+            | sed -n "s|^${SERVICE}/v||p" | sort -V | tail -n 1)
+
+          if [ -n "$NEWEST" ] && [ "$(printf '%s\n%s\n' "$NEWEST" "$VERSION" | sort -V | tail -n 1)" != "$VERSION" ]; then
+            echo "::error::${SERVICE} ${NEWEST} is already published, so rebuilding ${VERSION} would move the latest and major.minor tags backwards. Cut a new version instead."
+            exit 1
+          fi
+  build:
+    name: "${{ inputs.service }}"
+    needs: "resolve"
+    permissions:
+      contents: "write"
+      packages: "write"
+      id-token: "write"
+      attestations: "write"
+    uses: "./.github/workflows/_build-image.yaml"
+    with:
+      image: "${{ inputs.service }}"
+      workdir: "${{ needs.resolve.outputs.workdir }}"
+      language: "${{ needs.resolve.outputs.language }}"
+      push: true
+      version: "${{ inputs.version }}"
+      tag-name: "${{ needs.resolve.outputs.tag }}"
+    secrets: "inherit"

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,6 +1,6 @@
 # Releases
 
-Every container image in this repository is released by [release-please](https://github.com/googleapis/release-please). There is no manual dispatch, no version input, and no tag to push by hand.
+Every container image in this repository is released by [release-please](https://github.com/googleapis/release-please). You never choose a version or push a tag by hand. The one manual entry point is `Rebuild Release`, which only recovers a release that has already been tagged.
 
 ## Services
 
@@ -22,7 +22,7 @@ Every container image in this repository is released by [release-please](https:/
 4. In the same run, the build job for that service tests the tag and pushes the image to GHCR with a provenance attestation.
 5. The image reference and digest are appended to the release notes and the release is published.
 
-The draft is only published after the image is pushed, so a published release always has an image behind it. If the build fails the release stays a draft and the tag points at code with no image — re-run the workflow rather than cutting a new version.
+The draft is only published after the image is pushed, so a published release always has an image behind it. If the build fails the release stays a draft and the tag points at code that may have no image — see the troubleshooting section rather than cutting a new version.
 
 ## Choosing the version
 
@@ -48,12 +48,13 @@ Release-As: 2.0.0
 
 ## Configuration
 
-| File                                    | Purpose                                           |
-| --------------------------------------- | ------------------------------------------------- |
-| `release-please-config.json`            | Package list, release types, changelog sections   |
-| `.release-please-manifest.json`         | Current version of each package — source of truth |
-| `.github/workflows/release-please.yaml` | Opens release pull requests, dispatches builds    |
-| `.github/workflows/_build-image.yaml`   | Shared test and build workflow                    |
+| File                                     | Purpose                                                |
+| ---------------------------------------- | ------------------------------------------------------ |
+| `release-please-config.json`             | Package list, release types, changelog sections        |
+| `.release-please-manifest.json`          | Current version of each package — source of truth      |
+| `.github/workflows/release-please.yaml`  | Opens release pull requests, dispatches builds         |
+| `.github/workflows/_build-image.yaml`    | Shared test and build workflow                         |
+| `.github/workflows/rebuild-release.yaml` | Rebuilds a tagged release whose image never got pushed |
 
 ## Troubleshooting
 
@@ -61,4 +62,6 @@ Release-As: 2.0.0
 
 **The release pull request is not merging.** Mergify requires `summary / Check Results` to pass, the author to be `repo-operator-release-bot[bot]`, the branch to start with `release-please--branches--`, and the diff to touch `.release-please-manifest.json`. Anything else needs a human review.
 
-**A tag exists with no image.** The build failed after the tag was created. The release is still a draft. Re-run the failed run in `release-please.yaml`; do not delete the tag.
+**A tag exists with no image.** The build failed after the tag was created, so the release is still a draft. Run the `Rebuild Release` workflow with that service and version. Do not delete the tag and do not cut a new version.
+
+The workflow refuses to run unless the tag exists, the release is still a draft, and no newer version of that service has been published — the last check stops a rebuild from moving `latest` and `{major}.{minor}` backwards. It does not check the registry: the image is pushed before the release is published, so a draft release can still have an image behind it, and rebuilding overwrites that tag.


### PR DESCRIPTION
## Summary

Adds `Rebuild Release`, a `workflow_dispatch` recovery path for a release that has been tagged but whose image was never pushed, and fixes the documentation that already promised such a path existed.

## Linked Issue

Closes #2664

## Changes

- `.github/workflows/rebuild-release.yaml`: maps a service to its workdir, language and tag, verifies the release is recoverable, then calls `_build-image.yaml` with `push: true`
- `docs/releases.md`: documents the workflow, corrects the claim that there is no manual dispatch, and drops the claim that a published release implies no image can be overwritten

## Guards

The workflow refuses to run unless all three hold:

- the tag exists — it rebuilds an existing release, it does not create one
- the release is still a draft
- no newer version of that service has been published, since `_build-image.yaml` tags `latest` and `{major}.{minor}` unconditionally and a rebuild of an older version would move them backwards

It deliberately does not check the registry. The image is pushed before the release is published, so a draft release can still have an image behind it; that is exactly the state being recovered, and the rebuild overwrites that tag.

## Testing

Dispatch is the test. Once merged I will run it for `kata-tap-qdisc-fix 0.2.10` and `mcp-header-proxy 0.0.10`, which are the two releases currently stuck as drafts. Both should end up published with an image reference and digest in the notes.

qa-validator blocked the first version: the `resolve` job had `contents: read`, which cannot see a draft release at all, so the guard would have rejected every release the workflow exists to recover. It also caught the `latest` tag regression and the two inaccurate documentation claims. All fixed here.
