### PR TITLE
fix(traefik): scrape Traefik metrics into VictoriaMetrics

### DIFF
--- a/cluster/apps/traefik/traefik/app/values.yaml
+++ b/cluster/apps/traefik/traefik/app/values.yaml
@@ -29,6 +29,14 @@ tracing:
     http:
       enabled: true
       endpoint: http://victoria-traces-single-vt-single-server.observability.svc:10428/insert/opentelemetry/v1/traces
+metrics:
+  prometheus:
+    service:
+      enabled: true
+    serviceMonitor:
+      enabled: true
+      interval: 30s
+      scrapeTimeout: 10s
 ports:
   # aliasHeadersStrategy mitigates GHSA-rf44-j88r-hh8c: clients can spoof
   # ForwardAuth identity headers (X-authentik-*) using underscore or dot


### PR DESCRIPTION
## Summary

Traefik has been serving Prometheus metrics on its `metrics` entry point all along, but the chart creates neither a metrics `Service` nor a `ServiceMonitor` by default, so nothing ever scraped them. Queries for `traefik_*` series returned empty.

Enabling `metrics.prometheus.service` and `metrics.prometheus.serviceMonitor` is sufficient: the VictoriaMetrics operator converts the ServiceMonitor into a `VMServiceScrape`, and VMAgent runs with `selectAllByDefault: true`.

Found incidentally while validating #2679; pre-existing, not caused by that PR.

## Linked Issue

Closes #2705

## Changes

- `cluster/apps/traefik/traefik/app/values.yaml`: enable `metrics.prometheus.service` and `metrics.prometheus.serviceMonitor` (interval 30s, scrapeTimeout 10s)

## Testing

qa-validator run, verdict APPROVED ([report](https://github.com/anthony-spruyt/spruyt-labs/issues/2705#issuecomment-5453755922)):

- `helm template` before/after diff contains exactly three hunks: the new metrics Service, the new ServiceMonitor, and removal of the pod's `prometheus.io/*` annotations (the chart strips these when a ServiceMonitor is enabled, to prevent double-scraping). Zero changes to container args.
- Re-confirmed no regression on the recently added `aliasHeadersStrategy=delete` args, the web to websecure redirection, `websecure.http.tls`, `forwardedHeaders.trustedIPs`, and the TLSStore.
- ServiceMonitor selector includes `app.kubernetes.io/component: metrics`, which only the metrics Service carries, so it does not match the main LoadBalancer Service.
- Path renders as `/metrics` (chart default `entryPoint: metrics` survives Helm's deep merge), targetPort resolves against the named container port.
- Chart's `monitoring.coreos.com/v1` fail-gate passes; the CRD is present and 20+ ServiceMonitors are already Helm-managed in this cluster.
- Cardinality measured, not estimated: 315 series on the endpoint against roughly 346,500 active series. `addRoutersLabels` stays false and `headerLabels` stays empty.

## Notes

This rolls the Traefik pod (pod template and values ConfigMap hash both change). With `replicas: 1`, `maxUnavailable: 0`, `maxSurge: 1` the rollout is surge-first, but `externalTrafficPolicy: Local` means a brief blip is possible as the LoadBalancer backend node changes.
